### PR TITLE
Fix #60: Failure to convert `array`'s in MathListBuilder

### DIFF
--- a/CSharpMath.Tests/PreTypesetting/MathListBuilderTest.cs
+++ b/CSharpMath.Tests/PreTypesetting/MathListBuilderTest.cs
@@ -952,5 +952,26 @@ namespace CSharpMath.Tests {
       var latex = MathListBuilder.MathListToString(list);
       Assert.Equal(@"\color{#F00}{a}", latex);
     }
+
+    [Fact]
+    public void TestSingleColumnArray() {
+      var input = @"\begin{array}{l}a=14\\b=15\end{array}";
+      var list = MathLists.FromString(input);
+
+      Assert.Single(list);
+      var latex = MathListBuilder.MathListToString(list);
+      Assert.Equal(@"\begin{array}{l}a=14\\ b=15\end{array}", latex);
+    }
+
+    [Fact]
+    public void TestDoubleColumnArray() {
+      var input = @"\begin{array}{lr}x^2&\:x<0\\x^3&\:x\geq0\end{array}";
+      var list = MathLists.FromString(input);
+
+      Assert.Single(list);
+      var latex = MathListBuilder.MathListToString(list);
+      Assert.Equal(@"\begin{array}{lr}x^2&\: x<0\\ x^3&\: x\geq 0\end{array}", latex);
+    }
+
   }
 }

--- a/CSharpMath/Atoms/Factories/MathAtoms.cs
+++ b/CSharpMath/Atoms/Factories/MathAtoms.cs
@@ -501,12 +501,6 @@ namespace CSharpMath.Atoms {
       Style style;
       var table = new Table(environment) { Cells = rows };
       switch (environment) {
-        case null:
-          table.InterRowAdditionalSpacing = 1;
-          for (int i = 0; i < table.NColumns; i++) {
-            table.SetAlignment(ColumnAlignment.Left, i);
-          }
-          return table;
         case var _ when _matrixEnvironments.TryGetValue(environment, out var delimiters):
           table.Environment = "matrix"; // TableEnvironment is set to matrix as delimiters are converted to latex outside the table.
           table.InterColumnSpacing = 18;
@@ -528,6 +522,13 @@ namespace CSharpMath.Atoms {
           } else {
             return table;
           }
+        case null:
+        case "array":
+          table.InterRowAdditionalSpacing = 1;
+          for (int i = 0; i < table.NColumns; i++) {
+            table.SetAlignment(ColumnAlignment.Left, i);
+          }
+          return table;
         case "eqalign":
         case "split":
         case "aligned":


### PR DESCRIPTION
- Add @"array" as a recognised Table type