### PR TITLE
Show caret by itself

### DIFF
--- a/CSharpMath.Rendering/MathKeyboard.cs
+++ b/CSharpMath.Rendering/MathKeyboard.cs
@@ -17,8 +17,7 @@ namespace CSharpMath.Rendering {
     public void DrawCaret(ICanvas canvas, Structures.Color color, CaretShape shape) {
       if (!(Caret is CaretHandle caret))
         return;
-      if (!(Display.PointForIndex(TypesettingContext.Instance, InsertionIndex) is PointF cursorPosition))
-        return;
+      var cursorPosition = Display.PointForIndex(TypesettingContext.Instance, InsertionIndex) ?? Display.Position;
       cursorPosition.Y *= -1; //inverted canvas, blah blah
       var path = canvas.GetPath();
       path.BeginRead(1);


### PR DESCRIPTION
Will be closed: #56 

Current behaviour:

![gif](https://user-images.githubusercontent.com/16510738/68036856-8de0d100-fcd7-11e9-96b0-b287adb9ac28.gif)

Caret is floating by `y` axis. 
Caret position by `y` axis is depending on an atom so I'm not sure how to improve it. 

Maybe add some small value? 