### PR TITLE
Do not show caret when placeholder is in an active state 

### DIFF
--- a/CSharpMath.Editor/Keyboards/MathKeyboard.cs
+++ b/CSharpMath.Editor/Keyboards/MathKeyboard.cs
@@ -662,12 +662,14 @@ namespace CSharpMath.Editor {
         }
       }
       VisualizePlaceholders(MathList);
-      if(MathList.AtomAt(_insertionIndex) is IMathAtom atom && atom.AtomType is MathAtomType.Placeholder)
+      if (MathList.AtomAt(_insertionIndex) is IMathAtom atom && atom.AtomType is MathAtomType.Placeholder) {
         atom.Nucleus = Symbols.BlackSquare;
-      /* Find the insert point rect and create a caretView to draw the caret at this position. */
-
+        Caret = null;
+      } else {
+        /* Find the insert point rect and create a caretView to draw the caret at this position. */
+        Caret = new CaretHandle(Font.PointSize);
+      }
       // Check that we were returned a valid position before displaying a caret there.
-      Caret = new CaretHandle(Font.PointSize);
       RecreateDisplayFromMathList();
       RedrawRequested?.Invoke(this, EventArgs.Empty);
     }


### PR DESCRIPTION
Will be closed: #71 

A new behaviour:

![gif](https://user-images.githubusercontent.com/16510738/68072457-0d81a500-fd97-11e9-9e89-a710d1adc633.gif)


What do you think about adding a bool property to control the behaviour? 
Just in case if someone prefer seeing a caret. It will also reduce count of breaking change.

Draft until getting feedbacks. 
Also: thinking about appropriate test.