### PR TITLE
Fix dependency version of CI packages + SourceLink infrastructure

### DIFF
--- a/.github/workflows/Build all projects.yml
+++ b/.github/workflows/Build all projects.yml
@@ -29,7 +29,7 @@ jobs:
         name: NuGet packages
         path: .nupkgs/
     - name: Push generated packages to GitHub registry
-      # if: github.ref == 'refs/heads/master'
+      if: github.ref == 'refs/heads/master'
       run: |
         nuget sources add -name "GPR" -Source https://nuget.pkg.github.com/verybadcat/index.json -Username verybadcat -Password ${{ secrets.GITHUB_TOKEN }}
-        nuget push .nupkgs/ -Source "GPR" -SkipDuplicate
+        nuget push .nupkgs/*.nupkg -Source "GPR" -SkipDuplicate

--- a/.github/workflows/Build all projects.yml
+++ b/.github/workflows/Build all projects.yml
@@ -32,4 +32,4 @@ jobs:
       if: github.ref == 'refs/heads/master'
       run: |
         nuget sources add -name "GPR" -Source https://nuget.pkg.github.com/verybadcat/index.json -Username verybadcat -Password ${{ secrets.GITHUB_TOKEN }}
-        nuget push .nupkgs/*.nupkg -Source "GPR" -SkipDuplicate
+        nuget push .nupkgs/ -Source "GPR" -SkipDuplicate

--- a/.github/workflows/Build all projects.yml
+++ b/.github/workflows/Build all projects.yml
@@ -29,7 +29,7 @@ jobs:
         name: NuGet packages
         path: .nupkgs/
     - name: Push generated packages to GitHub registry
-      if: github.ref == 'refs/heads/master'
+      # if: github.ref == 'refs/heads/master'
       run: |
         nuget sources add -name "GPR" -Source https://nuget.pkg.github.com/verybadcat/index.json -Username verybadcat -Password ${{ secrets.GITHUB_TOKEN }}
         nuget push .nupkgs/ -Source "GPR" -SkipDuplicate

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,9 +9,9 @@
       CA1303,<!--Who localizes exception messages, anyway?-->
     </NoWarn>
 
-    <!--Ordered according to https://docs.microsoft.com/en-us/nuget/reference/msbuild-targets#pack-target-->
+    <!--NuGet properties: Ordered according to https://docs.microsoft.com/en-us/nuget/reference/msbuild-targets#pack-target-->
     <PackageId>$(MSBuildProjectName)</PackageId>
-    <PackageVersion>0.4.2</PackageVersion>
+    <PackageVersionRaw>0.4.2</PackageVersionRaw>
     <Authors>CSharpMath Contributors (verybadcat, Happypig375, charlesroddie, FoggyFinder)</Authors>
     <Title>$(PackageId)</Title>
     <!--Description property is defined in individual projects-->
@@ -33,6 +33,10 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryBranch>master</RepositoryBranch>
     <!--RepositoryCommit property is set dynamically below-->
+    
+    <!--SourceLink properties: Ordered according to https://github.com/dotnet/sourcelink#using-source-link-in-net-projects-->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     
@@ -54,14 +58,18 @@
     And !$([System.String]::IsNullOrEmpty($(GeneratePackageOnBuild)))
     And $(GeneratePackageOnBuild)">
     <None Include="$(MSBuildThisFileDirectory)Icon.png" Pack="true" PackagePath="" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
   <Target Name="AppendCISignatureToPackageVersion" BeforeTargets="BeforeBuild" Condition="$(MSBuildProjectName.StartsWith('CSharpMath'))">
     <Exec Command="git rev-parse HEAD" ConsoleToMSBuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="RepositoryCommit" />
     </Exec>
     <!-- Appending build date and time as metadata for version is blocked on https://github.community/t/bug-nuget-support-build-metadata-properly/117606 -->
-    <!-- <CreateProperty Value="$(PackageVersion)-ci-$(RepositoryCommit)+$([System.DateTime]::UtcNow.ToString('yyyy.MM.dd-HH.mm.ss'))"> -->
-    <CreateProperty Condition="$(CI)" Value="$(PackageVersion)-ci-$(RepositoryCommit)">
+    <!-- <CreateProperty Value="$(PackageVersionRaw)-ci-$(RepositoryCommit)+$([System.DateTime]::UtcNow.ToString('yyyy.MM.dd-HH.mm.ss'))"> -->
+    <CreateProperty Condition="!$([System.String]::IsNullOrEmpty($(CI))) And $(CI)" Value="$(PackageVersionRaw)-ci-$(RepositoryCommit)">
+      <Output TaskParameter="Value" PropertyName="PackageVersion" />
+    </CreateProperty>
+    <CreateProperty Condition="$([System.String]::IsNullOrEmpty($(CI))) Or !$(CI)" Value="$(PackageVersionRaw)">
       <Output TaskParameter="Value" PropertyName="PackageVersion" />
     </CreateProperty>
   </Target>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -61,7 +61,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
   <Target Name="AppendCISignatureToPackageVersion" Condition="$(MSBuildProjectName.StartsWith('CSharpMath'))">
-    <Exec Command="git rev-parse HEAD" ConsoleToMSBuild="true" EchoOff="true">
+    <Exec Command="git rev-parse HEAD" ConsoleToMSBuild="true" EchoOff="true" StandardOutputImportance="Low">
       <Output TaskParameter="ConsoleOutput" PropertyName="RepositoryCommit" />
     </Exec>
     <!-- Appending build date and time as metadata for version is blocked on https://github.community/t/bug-nuget-support-build-metadata-properly/117606 -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -33,6 +33,8 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryBranch>master</RepositoryBranch>
     <!--RepositoryCommit property is set dynamically below-->
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     
     <!--Info on NuGet packaging properties: https://github.com/NuGet/Home/wiki/Adding-nuget-pack-as-a-msbuild-target-->
     <GeneratePackageOnBuild Condition="

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -61,6 +61,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
   <Target Name="AppendCISignatureToPackageVersion" Condition="$(MSBuildProjectName.StartsWith('CSharpMath'))">
+    <!--Setting StandardOutputImportance to Low ensures that EchoOff works: https://github.com/Microsoft/msbuild/issues/2826-->
     <Exec Command="git rev-parse HEAD" ConsoleToMSBuild="true" EchoOff="true" StandardOutputImportance="Low">
       <Output TaskParameter="ConsoleOutput" PropertyName="RepositoryCommit" />
     </Exec>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <!--Directory.Build.props: MSBuild properties that are included in every project-->
 <!--Info: https://docs.microsoft.com/en-us/visualstudio/msbuild/customize-your-build?view=vs-2019#directorybuildprops-and-directorybuildtargets-->
-<Project>
+<Project InitialTargets="AppendCISignatureToPackageVersion">
   <PropertyGroup Condition="$(MSBuildProjectName.StartsWith('CSharpMath'))"> <!--Don't apply to Typography projects-->
     <LangVersion Condition="$(MSBuildProjectExtension) == '.csproj'">8.0</LangVersion> <!--Don't apply to F# projects-->
     <Nullable>enable</Nullable>
@@ -9,11 +9,9 @@
       CA1303,<!--Who localizes exception messages, anyway?-->
     </NoWarn>
 
-    <!--This is the same output as 'git rev-parse HEAD' or current commit SHA-->
-    <RepositoryCommit>$([System.IO.File]::ReadAllText($([System.IO.Path]::Combine($(MSBuildThisFileDirectory), ".git", "ORIG_HEAD"))))</RepositoryCommit>
-    <!--NuGet properties: Except RepositoryCommit, ordered according to https://docs.microsoft.com/en-us/nuget/reference/msbuild-targets#pack-target-->
+    <!--NuGet properties: Ordered according to https://docs.microsoft.com/en-us/nuget/reference/msbuild-targets#pack-target-->
     <PackageId>$(MSBuildProjectName)</PackageId>
-    <PackageVersion>0.4.2-ci-$(RepositoryCommit)</PackageVersion> <!--Please don't use the 4th version slot for CI versioning needs (see AppendCISignatureToPackageVersion below)-->
+    <PackageVersion>0.4.2</PackageVersion>
     <Authors>CSharpMath Contributors (verybadcat, Happypig375, charlesroddie, FoggyFinder)</Authors>
     <Title>$(PackageId)</Title>
     <!--Description property is defined in individual projects-->
@@ -61,15 +59,14 @@
     And $(GeneratePackageOnBuild)">
     <None Include="$(MSBuildThisFileDirectory)Icon.png" Pack="true" PackagePath="" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="GitInfo" Version="2.0.26" PrivateAssets="All" />
   </ItemGroup>
-  <Target Name="AppendCISignatureToPackageVersion" BeforeTargets="BeforeBuild" Condition="False And $(MSBuildProjectName.StartsWith('CSharpMath'))">
+  <Target Name="AppendCISignatureToPackageVersion" Condition="$(MSBuildProjectName.StartsWith('CSharpMath'))">
     <Exec Command="git rev-parse HEAD" ConsoleToMSBuild="true" EchoOff="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="RepositoryCommit" />
     </Exec>
     <!-- Appending build date and time as metadata for version is blocked on https://github.community/t/bug-nuget-support-build-metadata-properly/117606 -->
-    <!-- <CreateProperty Value="$(PackageVersion).1-ci-$(RepositoryCommit)+$([System.DateTime]::UtcNow.ToString('yyyy.MM.dd-HH.mm.ss'))"> -->
-    <CreateProperty Condition="!$([System.String]::IsNullOrEmpty($(CI))) And $(CI)" Value="$(PackageVersion).1-ci-$(RepositoryCommit)">
+    <!-- <CreateProperty Value="$(PackageVersion)-ci-$(RepositoryCommit)+$([System.DateTime]::UtcNow.ToString('yyyy.MM.dd-HH.mm.ss'))"> -->
+    <CreateProperty Condition="!$([System.String]::IsNullOrEmpty($(CI))) And $(CI)" Value="$(PackageVersion)-ci-$(RepositoryCommit)">
       <Output TaskParameter="Value" PropertyName="PackageVersion" />
     </CreateProperty>
   </Target>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -32,9 +32,7 @@
     <RepositoryUrl>https://github.com/verybadcat/CSharpMath.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryBranch>master</RepositoryBranch>
-    <RepositoryCommit>
-      6678311f2f4f711ce6992e20ea31cd095205f651
-    </RepositoryCommit>
+    <!--RepositoryCommit property is set dynamically below-->
     
     <!--Info on NuGet packaging properties: https://github.com/NuGet/Home/wiki/Adding-nuget-pack-as-a-msbuild-target-->
     <GeneratePackageOnBuild Condition="
@@ -55,17 +53,13 @@
     And $(GeneratePackageOnBuild)">
     <None Include="$(MSBuildThisFileDirectory)Icon.png" Pack="true" PackagePath="" />
   </ItemGroup>
-  <Target Name="AppendCISignatureToPackageVersion" BeforeTargets="BeforeBuild" Condition="
-    $(MSBuildProjectName.StartsWith('CSharpMath'))
-    And !$([System.String]::IsNullOrEmpty($(GeneratePackageOnBuild)))
-    And $(GeneratePackageOnBuild)
-    And $(CI)">
+  <Target Name="AppendCISignatureToPackageVersion" BeforeTargets="BeforeBuild" Condition="$(MSBuildProjectName.StartsWith('CSharpMath'))">
     <Exec Command="git rev-parse HEAD" ConsoleToMSBuild="true">
-      <Output TaskParameter="ConsoleOutput" PropertyName="GitCommit" />
+      <Output TaskParameter="ConsoleOutput" PropertyName="RepositoryCommit" />
     </Exec>
     <!-- Appending build date and time as metadata for version is blocked on https://github.community/t/bug-nuget-support-build-metadata-properly/117606 -->
-    <!-- <CreateProperty Value="$(PackageVersion)-ci-$(GitCommit)+$([System.DateTime]::UtcNow.ToString('yyyy.MM.dd-HH.mm.ss'))"> -->
-    <CreateProperty Value="$(PackageVersion)-ci-$(GitCommit)">
+    <!-- <CreateProperty Value="$(PackageVersion)-ci-$(RepositoryCommit)+$([System.DateTime]::UtcNow.ToString('yyyy.MM.dd-HH.mm.ss'))"> -->
+    <CreateProperty Condition="$(CI)" Value="$(PackageVersion)-ci-$(RepositoryCommit)">
       <Output TaskParameter="Value" PropertyName="PackageVersion" />
     </CreateProperty>
   </Target>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,9 +9,11 @@
       CA1303,<!--Who localizes exception messages, anyway?-->
     </NoWarn>
 
-    <!--NuGet properties: Ordered according to https://docs.microsoft.com/en-us/nuget/reference/msbuild-targets#pack-target-->
+    <!--This is the same output as 'git rev-parse HEAD' or current commit SHA-->
+    <RepositoryCommit>$([System.IO.File]::ReadAllText($([System.IO.Path]::Combine($(MSBuildThisFileDirectory), ".git", "ORIG_HEAD"))))</RepositoryCommit>
+    <!--NuGet properties: Except RepositoryCommit, ordered according to https://docs.microsoft.com/en-us/nuget/reference/msbuild-targets#pack-target-->
     <PackageId>$(MSBuildProjectName)</PackageId>
-    <PackageVersionRaw>0.4.2</PackageVersionRaw>
+    <PackageVersion>0.4.2-ci-$(RepositoryCommit)</PackageVersion> <!--Please don't use the 4th version slot for CI versioning needs (see AppendCISignatureToPackageVersion below)-->
     <Authors>CSharpMath Contributors (verybadcat, Happypig375, charlesroddie, FoggyFinder)</Authors>
     <Title>$(PackageId)</Title>
     <!--Description property is defined in individual projects-->
@@ -59,17 +61,15 @@
     And $(GeneratePackageOnBuild)">
     <None Include="$(MSBuildThisFileDirectory)Icon.png" Pack="true" PackagePath="" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="GitInfo" Version="2.0.26" PrivateAssets="All" />
   </ItemGroup>
-  <Target Name="AppendCISignatureToPackageVersion" BeforeTargets="BeforeBuild" Condition="$(MSBuildProjectName.StartsWith('CSharpMath'))">
-    <Exec Command="git rev-parse HEAD" ConsoleToMSBuild="true">
+  <Target Name="AppendCISignatureToPackageVersion" BeforeTargets="BeforeBuild" Condition="False And $(MSBuildProjectName.StartsWith('CSharpMath'))">
+    <Exec Command="git rev-parse HEAD" ConsoleToMSBuild="true" EchoOff="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="RepositoryCommit" />
     </Exec>
     <!-- Appending build date and time as metadata for version is blocked on https://github.community/t/bug-nuget-support-build-metadata-properly/117606 -->
-    <!-- <CreateProperty Value="$(PackageVersionRaw)-ci-$(RepositoryCommit)+$([System.DateTime]::UtcNow.ToString('yyyy.MM.dd-HH.mm.ss'))"> -->
-    <CreateProperty Condition="!$([System.String]::IsNullOrEmpty($(CI))) And $(CI)" Value="$(PackageVersionRaw)-ci-$(RepositoryCommit)">
-      <Output TaskParameter="Value" PropertyName="PackageVersion" />
-    </CreateProperty>
-    <CreateProperty Condition="$([System.String]::IsNullOrEmpty($(CI))) Or !$(CI)" Value="$(PackageVersionRaw)">
+    <!-- <CreateProperty Value="$(PackageVersion).1-ci-$(RepositoryCommit)+$([System.DateTime]::UtcNow.ToString('yyyy.MM.dd-HH.mm.ss'))"> -->
+    <CreateProperty Condition="!$([System.String]::IsNullOrEmpty($(CI))) And $(CI)" Value="$(PackageVersion).1-ci-$(RepositoryCommit)">
       <Output TaskParameter="Value" PropertyName="PackageVersion" />
     </CreateProperty>
   </Target>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 <!--Info: https://docs.microsoft.com/en-us/visualstudio/msbuild/customize-your-build?view=vs-2019#directorybuildprops-and-directorybuildtargets-->
 <Project InitialTargets="AppendCISignatureToPackageVersion">
   <PropertyGroup Condition="$(MSBuildProjectName.StartsWith('CSharpMath'))"> <!--Don't apply to Typography projects-->
-    <LangVersion Condition="$(MSBuildProjectExtension) == '.csproj'">8.0</LangVersion> <!--Don't apply to F# projects-->
+    <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
     <NoWarn>
       CA1062,<!--Obsolete with C# 8 nullability annotations-->

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -291,7 +291,14 @@ For those who wish to be even more updated than prereleases, you can opt in to t
   <PackageReference Include="PACKAGE" Version="VERSION" />
 </ItemGroup>
 ```
-7. Replace `PACKAGE` in the above file by the package name in the webpage, e.g. `CSharpMath.SkiaSharp`, and `VERSION` by the version in the webpage, e.g. `0.4.2-ci-9db8a6dec29202804764fab9d6f7f19e43c3c083`. The 40-digit hexadecimal number at the end of the version is the Git commit that was the package was built on. CI versions are after the current version, aka `0.4.1-ci-xxx` → `0.4.2` → `0.4.2-ci-xxx`.
+7. Replace `PACKAGE` in the above file by the package name in the webpage, e.g. `CSharpMath.SkiaSharp`, and `VERSION` by the version in the webpage, e.g. `0.4.2-ci-9db8a6dec29202804764fab9d6f7f19e43c3c083`. The 40-digit hexadecimal number at the end of the version is the Git commit that was the package was built on. CI versions for a version are newer than that version, aka chronologically `0.4.1-ci-xxx` → `0.4.2` → `0.4.2-ci-xxx`.
+### SourceLink for CI packages
+
+Unfortunately, non-NuGet.org feeds do not support `.snupkg`s, so you will have to download all the packages yourself.
+1. Go to https://github.com/verybadcat/CSharpMath/actions?query=workflow%3ABuild and open the latest build
+2. Download artifacts
+3. Extract the files a folder
+4. Add the folder as a local NuGet feed to Visual Studio according to https://docs.microsoft.com/en-gb/nuget/consume-packages/install-use-packages-visual-studio#package-sources
 
 # Project structure
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -295,10 +295,11 @@ For those who wish to be even more updated than prereleases, you can opt in to t
 ### SourceLink for CI packages
 
 Unfortunately, non-NuGet.org feeds do not support `.snupkg`s, so you will have to download all the packages yourself.
-1. Go to https://github.com/verybadcat/CSharpMath/actions?query=workflow%3ABuild and open the latest build
-2. Download artifacts
-3. Extract the files a folder
-4. Add the folder as a local NuGet feed to Visual Studio according to https://docs.microsoft.com/en-gb/nuget/consume-packages/install-use-packages-visual-studio#package-sources
+1. Go to https://github.com/verybadcat/CSharpMath/actions?query=workflow%3ABuild
+2. Open the latest build
+3. Download artifacts
+4. Extract the files to a folder
+5. Add the folder as a local NuGet feed to Visual Studio according to https://docs.microsoft.com/en-gb/nuget/consume-packages/install-use-packages-visual-studio#package-sources
 
 # Project structure
 


### PR DESCRIPTION
Per https://github.com/dotnet/sourcelink/issues/255, non-NuGet feeds do not support `.snupkg`s, so they are not available for CI packages.