### PR TITLE
Tidy MathListIndex

### DIFF
--- a/CSharpMath.Core.Tests/Atom/DictionaryTests.cs
+++ b/CSharpMath.Core.Tests/Atom/DictionaryTests.cs
@@ -1,7 +1,7 @@
 using CSharpMath.Atom;
 using Xunit;
 
-namespace CSharpMath.Core.Tests {
+namespace CSharpMath.Core.AtomTests {
   public class DictionaryTests {
     private AliasBiDictionary<string, int> InitTestDict() =>
       new AliasBiDictionary<string, int> {

--- a/CSharpMath.Core.Tests/Atom/LaTeXParserTest.cs
+++ b/CSharpMath.Core.Tests/Atom/LaTeXParserTest.cs
@@ -6,7 +6,7 @@ using CSharpMath.Atom;
 using CSharpMath.Atom.Atoms;
 using Xunit;
 
-namespace CSharpMath.Core.Tests {
+namespace CSharpMath.Core.AtomTests {
   public class LaTeXParserTest {
     public static MathList ParseLaTeX(string latex) {
       var builder = new LaTeXParser(latex);

--- a/CSharpMath.Core.Tests/Atom/LaTeXSettingsTests.cs
+++ b/CSharpMath.Core.Tests/Atom/LaTeXSettingsTests.cs
@@ -1,6 +1,6 @@
 using System.Linq;
 using Xunit;
-namespace CSharpMath.Core.Tests {
+namespace CSharpMath.Core.AtomTests {
   using CSharpMath.Atom;
   using CSharpMath.Atom.Atoms;
   using static LaTeXParserTest;

--- a/CSharpMath.Core.Tests/Atom/MathAtomTest.cs
+++ b/CSharpMath.Core.Tests/Atom/MathAtomTest.cs
@@ -3,7 +3,7 @@ using CSharpMath.Atom;
 using CSharpMath.Atom.Atoms;
 using Xunit;
 
-namespace CSharpMath.Core.Tests {
+namespace CSharpMath.Core.AtomTests {
   public class MathAtomTest {
     internal static void CheckClone(MathAtom? original, MathAtom? clone) =>
       MathListTest.CheckClone(original, clone);

--- a/CSharpMath.Core.Tests/Atom/MathListTest.cs
+++ b/CSharpMath.Core.Tests/Atom/MathListTest.cs
@@ -4,7 +4,7 @@ using CSharpMath.Atom;
 using CSharpMath.Atom.Atoms;
 using Xunit;
 
-namespace CSharpMath.Core.Tests {
+namespace CSharpMath.Core.AtomTests {
   using Range = Atom.Range;
   public class MathListTest {
     internal static void CheckClone(MathAtom? original, MathAtom? clone) {

--- a/CSharpMath.Core.Tests/Display/ApproximateAssertions.cs
+++ b/CSharpMath.Core.Tests/Display/ApproximateAssertions.cs
@@ -4,7 +4,7 @@ using System.Drawing;
 using System.Runtime.CompilerServices;
 using Xunit;
 
-namespace CSharpMath.Core.Tests {
+namespace CSharpMath.Core.DisplayTests {
   [DebuggerStepThrough] // Debugger should stop at the line that uses these functions
   public static class Approximately {
     const double DefaultTolerance = 0.001;

--- a/CSharpMath.Core.Tests/Display/FontChangingTests.cs
+++ b/CSharpMath.Core.Tests/Display/FontChangingTests.cs
@@ -1,4 +1,4 @@
-namespace CSharpMath.Core.Tests {
+namespace CSharpMath.Core.DisplayTests {
   using Atom;
   using Xunit;
   public class FontChangingTests {

--- a/CSharpMath.Core.Tests/Display/MockTests.cs
+++ b/CSharpMath.Core.Tests/Display/MockTests.cs
@@ -2,7 +2,7 @@ using CSharpMath.Display;
 using Xunit;
 using TGlyph = System.Text.Rune;
 
-namespace CSharpMath.Core.Tests {
+namespace CSharpMath.Core.DisplayTests {
   using BackEnd;
   // purpose of this class is to make sure our mocks behave as expected.
   public class MockTests {

--- a/CSharpMath.Core.Tests/Display/TypesetterTests.cs
+++ b/CSharpMath.Core.Tests/Display/TypesetterTests.cs
@@ -8,10 +8,10 @@ using Xunit;
 using TFont = CSharpMath.Core.BackEnd.TestFont;
 using TGlyph = System.Text.Rune;
 
-namespace CSharpMath.Core.Tests {
+namespace CSharpMath.Core.DisplayTests {
   public class TypesetterTests {
     internal static ListDisplay<TFont, TGlyph> ParseLaTeXToDisplay(string latex) =>
-      Typesetter.CreateLine(LaTeXParserTest.ParseLaTeX(latex), _font, _context, LineStyle.Display);
+      Typesetter.CreateLine(AtomTests.LaTeXParserTest.ParseLaTeX(latex), _font, _context, LineStyle.Display);
 
     private static readonly TFont _font = new TFont(20);
     private static readonly TypesettingContext<TFont, TGlyph> _context = BackEnd.TestTypesettingContext.Instance;

--- a/CSharpMath.Core.Tests/Editor/CaretTests.cs
+++ b/CSharpMath.Core.Tests/Editor/CaretTests.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 using Xunit;
 using TGlyph = System.Text.Rune;
 
-namespace CSharpMath.Core.Tests {
+namespace CSharpMath.Core.EditorTests {
   using Atom;
   using BackEnd;
   using Editor;
@@ -212,7 +212,7 @@ namespace CSharpMath.Core.Tests {
       Assert.True(keyboard.InsertionPositionHighlighted);
       Assert.False(keyboard.ShouldDrawCaret);
 
-      keyboard.InsertionIndex = MathListIndex.Level0Index(keyboard.MathList.Count);
+      keyboard.InsertionIndex = new MathListIndex(keyboard.MathList.Count);
       Assert.True(keyboard.InsertionPositionHighlighted);
       Assert.True(keyboard.ShouldDrawCaret);
       Assert.Equal(LaTeXSettings.PlaceholderRestingNucleus, outer.Nucleus);

--- a/CSharpMath.Core.Tests/Editor/IndexForPointTests.cs
+++ b/CSharpMath.Core.Tests/Editor/IndexForPointTests.cs
@@ -1,7 +1,7 @@
 using System.Drawing;
 using Xunit;
 
-namespace CSharpMath.Core.Tests {
+namespace CSharpMath.Core.EditorTests {
   using Atom;
   using BackEnd;
   using Editor;
@@ -14,18 +14,13 @@ namespace CSharpMath.Core.Tests {
         int index, params (SubIndex subType, int subIndex)[] subIndexRecursive) {
         switch (subIndexRecursive.Length) {
           case 0:
-            var mathListIndex = MathListIndex.Level0Index(index);
+            var mathListIndex = new MathListIndex(index);
             goto default;
           case var _:
-            mathListIndex = MathListIndex.Level0Index(
-              subIndexRecursive[^1].subIndex);
+            mathListIndex = new(subIndexRecursive[^1].subIndex);
             for (var i = subIndexRecursive.Length - 2; i >= 0; i--)
-              mathListIndex = MathListIndex.IndexAtLocation(
-                subIndexRecursive[i].subIndex,
-                subIndexRecursive[i + 1].subType,
-                mathListIndex);
-            mathListIndex = MathListIndex.IndexAtLocation(index,
-              subIndexRecursive[0].subType, mathListIndex);
+              mathListIndex = mathListIndex.WrapInIndex(subIndexRecursive[i].subIndex, subIndexRecursive[i + 1].subType);
+            mathListIndex = mathListIndex.WrapInIndex(index, subIndexRecursive[0].subType);
             goto default;
           default:
             Add(new PointF((float)point.x, (float)point.y), mathListIndex);

--- a/CSharpMath.Core.Tests/Editor/IndexForPointTests.cs
+++ b/CSharpMath.Core.Tests/Editor/IndexForPointTests.cs
@@ -19,8 +19,8 @@ namespace CSharpMath.Core.EditorTests {
           case var _:
             mathListIndex = new(subIndexRecursive[^1].subIndex);
             for (var i = subIndexRecursive.Length - 2; i >= 0; i--)
-              mathListIndex = mathListIndex.WrapInIndex(subIndexRecursive[i].subIndex, subIndexRecursive[i + 1].subType);
-            mathListIndex = mathListIndex.WrapInIndex(index, subIndexRecursive[0].subType);
+              mathListIndex = mathListIndex.Wrap(subIndexRecursive[i].subIndex, subIndexRecursive[i + 1].subType);
+            mathListIndex = mathListIndex.Wrap(index, subIndexRecursive[0].subType);
             goto default;
           default:
             Add(new PointF((float)point.x, (float)point.y), mathListIndex);

--- a/CSharpMath.Core.Tests/Editor/KeyPressTests.cs
+++ b/CSharpMath.Core.Tests/Editor/KeyPressTests.cs
@@ -7,7 +7,7 @@ using K = CSharpMath.Editor.MathKeyboardInput;
 using T = Xunit.InlineDataAttribute;
 using TGlyph = System.Text.Rune;
 
-namespace CSharpMath.Core.Tests {
+namespace CSharpMath.Core.EditorTests {
   using BackEnd;
   using Editor;
   public class KeyPressTests {

--- a/CSharpMath.Core.Tests/Editor/PointForIndexTests.cs
+++ b/CSharpMath.Core.Tests/Editor/PointForIndexTests.cs
@@ -1,8 +1,8 @@
 using System.Drawing;
 using Xunit;
 
-namespace CSharpMath.Core.Tests {
-  using Atom;
+namespace CSharpMath.Core.EditorTests {
+  using DisplayTests;
   using BackEnd;
   using Editor;
   using static IndexForPointTests;

--- a/CSharpMath.Core.Tests/Editor/PointForIndexTests.cs
+++ b/CSharpMath.Core.Tests/Editor/PointForIndexTests.cs
@@ -2,8 +2,8 @@ using System.Drawing;
 using Xunit;
 
 namespace CSharpMath.Core.EditorTests {
-  using DisplayTests;
   using BackEnd;
+  using DisplayTests;
   using Editor;
   using static IndexForPointTests;
   // Use CSharpMath.Core.Example to visualize the test cases

--- a/CSharpMath.Rendering.Tests/TestRendering.cs
+++ b/CSharpMath.Rendering.Tests/TestRendering.cs
@@ -163,7 +163,7 @@ Was added in 0.1.0-pre4; working in 0.1.0-pre5; fully tested in 0.1.0-pre6. \[\f
         return;
       }
 
-      DisplayTests.Approximately.Equal(expectedStream.Length, actualStream.Length, expectedStream.Length * FileSizeTolerance);
+      Core.DisplayTests.Approximately.Equal(expectedStream.Length, actualStream.Length, expectedStream.Length * FileSizeTolerance);
       if (FileSizeTolerance == 0)
         Assert.True(contentsMatch, "The images differ.");
     }

--- a/CSharpMath.Rendering.Tests/TestRendering.cs
+++ b/CSharpMath.Rendering.Tests/TestRendering.cs
@@ -163,7 +163,7 @@ Was added in 0.1.0-pre4; working in 0.1.0-pre5; fully tested in 0.1.0-pre6. \[\f
         return;
       }
 
-      Core.Tests.Approximately.Equal(expectedStream.Length, actualStream.Length, expectedStream.Length * FileSizeTolerance);
+      DisplayTests.Approximately.Equal(expectedStream.Length, actualStream.Length, expectedStream.Length * FileSizeTolerance);
       if (FileSizeTolerance == 0)
         Assert.True(contentsMatch, "The images differ.");
     }

--- a/CSharpMath/Atom/MathList.cs
+++ b/CSharpMath/Atom/MathList.cs
@@ -19,7 +19,7 @@ namespace CSharpMath.Atom {
     public MathList(params MathAtom[] atoms) => Atoms = new List<MathAtom>(atoms);
 
     /// <returns>The last <see cref="MathAtom"/> that is not a <see cref="Comment"/>,
-    /// or <see cref="null"/> when <see cref="Atoms"/> is empty.</returns>
+    /// or <see langword="null"/> when <see cref="Atoms"/> is empty.</returns>
 #if !NETSTANDARD2_0 && !NET45
     [System.Diagnostics.CodeAnalysis.DisallowNull]
 #endif

--- a/CSharpMath/CSharpMath.csproj
+++ b/CSharpMath/CSharpMath.csproj
@@ -13,6 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+	<PackageReference Include="IsExternalInit" Version="1.0.0" PrivateAssets="all" />
     <PackageReference Include="System.Memory" Version="4.6.3" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
     <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="all" />

--- a/CSharpMath/Editor/Extensions/FractionDisplay.cs
+++ b/CSharpMath/Editor/Extensions/FractionDisplay.cs
@@ -5,32 +5,30 @@ namespace CSharpMath.Editor {
   using Display.FrontEnd;
 
   partial class Extensions {
-    public static MathListIndex IndexForPoint<TFont, TGlyph>(
+    public static MathListIndex? IndexForPoint<TFont, TGlyph>(
       this FractionDisplay<TFont, TGlyph> self,
       TypesettingContext<TFont, TGlyph> context,
       PointF point) where TFont : IFont<TGlyph> =>
       // We can be before or after the fraction
       point.X < self.Position.X - PixelDelta
-      //We are before the fraction, so
-      ? MathListIndex.Level0Index(self.Range.Location)
+      // We are before the fraction
+      ? new(self.Range.Location)
       : point.X > self.Position.X + self.Width + PixelDelta
-      //We are after the fraction
-      ? MathListIndex.Level0Index(self.Range.End)
+      // We are after the fraction
+      ? new(self.Range.End)
       : point.Y > self.LinePosition + PixelDelta
-      ? MathListIndex.IndexAtLocation(self.Range.Location,
-          MathListSubIndexType.Numerator, self.Numerator.IndexForPoint(context, point))
+      ? self.Numerator.IndexForPoint(context, point)?.WrapInIndex(self.Range.Location, MathListSubIndexType.Numerator)
       : point.Y < self.LinePosition - PixelDelta
-      ? MathListIndex.IndexAtLocation(self.Range.Location,
-          MathListSubIndexType.Denominator, self.Denominator.IndexForPoint(context, point))
+      ? self.Denominator.IndexForPoint(context, point)?.WrapInIndex(self.Range.Location, MathListSubIndexType.Denominator)
       : point.X > self.Position.X + self.Width / 2
-      ? MathListIndex.Level0Index(self.Range.End)
-      : MathListIndex.Level0Index(self.Range.Location);
+      ? new(self.Range.End)
+      : new(self.Range.Location);
 
     public static PointF? PointForIndex<TFont, TGlyph>(
       this FractionDisplay<TFont, TGlyph> self,
       TypesettingContext<TFont, TGlyph> _,
       MathListIndex index) where TFont : IFont<TGlyph> =>
-      index.SubIndexType != MathListSubIndexType.None
+      index.SubIndexInfo is { }
       ? throw new ArgumentException
         ("The subindex must be none to get the closest point for it.", nameof(index))
       : index.AtomIndex == self.Range.End
@@ -42,7 +40,7 @@ namespace CSharpMath.Editor {
     public static void HighlightCharacterAt<TFont, TGlyph>(
       this FractionDisplay<TFont, TGlyph> self,
       MathListIndex index, Color color) where TFont : IFont<TGlyph> {
-      if (index.SubIndexType != MathListSubIndexType.None)
+      if (index.SubIndexInfo is { })
         throw new ArgumentException
           ("The subindex must be none to get the highlight a character in it.", nameof(index));
       self.Highlight(color);

--- a/CSharpMath/Editor/Extensions/FractionDisplay.cs
+++ b/CSharpMath/Editor/Extensions/FractionDisplay.cs
@@ -17,9 +17,9 @@ namespace CSharpMath.Editor {
       // We are after the fraction
       ? new(self.Range.End)
       : point.Y > self.LinePosition + PixelDelta
-      ? self.Numerator.IndexForPoint(context, point)?.WrapInIndex(self.Range.Location, MathListSubIndexType.Numerator)
+      ? self.Numerator.IndexForPoint(context, point)?.Wrap(self.Range.Location, MathListSubIndexType.Numerator)
       : point.Y < self.LinePosition - PixelDelta
-      ? self.Denominator.IndexForPoint(context, point)?.WrapInIndex(self.Range.Location, MathListSubIndexType.Denominator)
+      ? self.Denominator.IndexForPoint(context, point)?.Wrap(self.Range.Location, MathListSubIndexType.Denominator)
       : point.X > self.Position.X + self.Width / 2
       ? new(self.Range.End)
       : new(self.Range.Location);

--- a/CSharpMath/Editor/Extensions/IGlyphDisplay.cs
+++ b/CSharpMath/Editor/Extensions/IGlyphDisplay.cs
@@ -10,14 +10,14 @@ namespace CSharpMath.Editor {
       TypesettingContext<TFont, TGlyph> _,
       PointF point) where TFont : IFont<TGlyph> =>
       point.X > self.Position.X + self.Width / 2
-      ? MathListIndex.Level0Index(self.Range.End)
-      : MathListIndex.Level0Index(self.Range.Location);
+      ? new(self.Range.End)
+      : new(self.Range.Location);
 
     public static PointF? PointForIndex<TFont, TGlyph>(
       this IGlyphDisplay<TFont, TGlyph> self,
       TypesettingContext<TFont, TGlyph> _,
       MathListIndex index) where TFont : IFont<TGlyph> =>
-      index.SubIndexType != MathListSubIndexType.None
+      index.SubIndexInfo is { }
       ? throw new ArgumentException
         ("The subindex must be none to get the closest point for it.", nameof(index))
       : index.AtomIndex == self.Range.End
@@ -29,7 +29,7 @@ namespace CSharpMath.Editor {
     public static void HighlightCharacterAt<TFont, TGlyph>(
       this IGlyphDisplay<TFont, TGlyph> self,
       MathListIndex index, Color color) where TFont : IFont<TGlyph> {
-      if (index.SubIndexType != MathListSubIndexType.None)
+      if (index.SubIndexInfo is { })
         throw new ArgumentException
           ("The subindex must be none to get the highlight a character in it.", nameof(index));
       self.Highlight(color);

--- a/CSharpMath/Editor/Extensions/InnerDisplay.cs
+++ b/CSharpMath/Editor/Extensions/InnerDisplay.cs
@@ -5,25 +5,24 @@ namespace CSharpMath.Editor {
   using Display.FrontEnd;
 
   partial class Extensions {
-    public static MathListIndex IndexForPoint<TFont, TGlyph>(
+    public static MathListIndex? IndexForPoint<TFont, TGlyph>(
       this InnerDisplay<TFont, TGlyph> self,
       TypesettingContext<TFont, TGlyph> context,
       PointF point) where TFont : IFont<TGlyph> =>
       // We can be before or after the inner
       point.X < self.Position.X + (self.Left?.Width / 2 ?? 0)
       //We are before the inner, so
-      ? MathListIndex.Level0Index(self.Range.Location)
+      ? new(self.Range.Location)
       : point.X > self.Position.X + self.Width - (self.Right?.Width / 2 ?? 0)
       //We are after the inner
-      ? MathListIndex.Level0Index(self.Range.End)
-      : MathListIndex.IndexAtLocation(self.Range.Location,
-          MathListSubIndexType.Inner, self.Inner.IndexForPoint(context, point));
+      ? new(self.Range.End)
+      : self.Inner.IndexForPoint(context, point)?.WrapInIndex(self.Range.Location, MathListSubIndexType.Inner);
 
     public static PointF? PointForIndex<TFont, TGlyph>(
       this InnerDisplay<TFont, TGlyph> self,
       TypesettingContext<TFont, TGlyph> _,
       MathListIndex index) where TFont : IFont<TGlyph> =>
-      index.SubIndexType != MathListSubIndexType.None
+      index.SubIndexInfo is { }
       ? throw new ArgumentException
         ("The subindex must be none to get the closest point for it.", nameof(index))
       : index.AtomIndex == self.Range.End
@@ -35,7 +34,7 @@ namespace CSharpMath.Editor {
     public static void HighlightCharacterAt<TFont, TGlyph>(
       this InnerDisplay<TFont, TGlyph> self,
       MathListIndex index, Color color) where TFont : IFont<TGlyph> {
-      if (index.SubIndexType != MathListSubIndexType.None)
+      if (index.SubIndexInfo is { })
         throw new ArgumentException
           ("The subindex must be none to get the highlight a character in it.", nameof(index));
       self.Highlight(color);

--- a/CSharpMath/Editor/Extensions/InnerDisplay.cs
+++ b/CSharpMath/Editor/Extensions/InnerDisplay.cs
@@ -16,7 +16,7 @@ namespace CSharpMath.Editor {
       : point.X > self.Position.X + self.Width - (self.Right?.Width / 2 ?? 0)
       //We are after the inner
       ? new(self.Range.End)
-      : self.Inner.IndexForPoint(context, point)?.WrapInIndex(self.Range.Location, MathListSubIndexType.Inner);
+      : self.Inner.IndexForPoint(context, point)?.Wrap(self.Range.Location, MathListSubIndexType.Inner);
 
     public static PointF? PointForIndex<TFont, TGlyph>(
       this InnerDisplay<TFont, TGlyph> self,

--- a/CSharpMath/Editor/Extensions/LargeOpLimitsDisplay.cs
+++ b/CSharpMath/Editor/Extensions/LargeOpLimitsDisplay.cs
@@ -6,35 +6,32 @@ namespace CSharpMath.Editor {
   using Display.FrontEnd;
 
   partial class Extensions {
-    public static MathListIndex IndexForPoint<TFont, TGlyph>(
+    public static MathListIndex? IndexForPoint<TFont, TGlyph>(
       this LargeOpLimitsDisplay<TFont, TGlyph> self,
       TypesettingContext<TFont, TGlyph> context,
       PointF point) where TFont : IFont<TGlyph> =>
       // We can be before or after the large operator
       point.X < self.Position.X - PixelDelta
       // We are before the large operator, so
-      ? MathListIndex.Level0Index(self.Range.Location)
+      ? new(self.Range.Location)
       : point.X > self.Position.X + self.Width + PixelDelta
       // We are after the large operator
-      ? MathListIndex.Level0Index(self.Range.End)
+      ? new(self.Range.End)
       : self.UpperLimit is { } u && point.Y > self.Position.Y + u.Position.Y - PixelDelta
-      ? MathListIndex.IndexAtLocation(self.Range.Location,
-          MathListSubIndexType.Superscript, u.IndexForPoint(context, point))
+      ? u.IndexForPoint(context, point)?.WrapInIndex(self.Range.Location, MathListSubIndexType.Superscript)
       : self.LowerLimit is { } l && point.Y < self.Position.Y + l.Position.Y + l.DisplayBounds().Height + PixelDelta
-      ? MathListIndex.IndexAtLocation(self.Range.Location,
-          MathListSubIndexType.Subscript, l.IndexForPoint(context, point))
+      ? l.IndexForPoint(context, point)?.WrapInIndex(self.Range.Location, MathListSubIndexType.Subscript)
       : point.X > self.Position.X + self.Width * 3 / 4
-      ? MathListIndex.Level0Index(self.Range.End)
+      ? new(self.Range.End)
       : point.X > self.Position.X + self.Width / 2
-      ? MathListIndex.IndexAtLocation(self.Range.Location,
-        MathListSubIndexType.BetweenBaseAndScripts, MathListIndex.Level0Index(1))
-      : MathListIndex.Level0Index(self.Range.Location);
+      ? new(self.Range.Location, new(MathListSubIndexType.BetweenBaseAndScripts, new(1)))
+      : new(self.Range.Location);
 
     public static PointF? PointForIndex<TFont, TGlyph>(
       this LargeOpLimitsDisplay<TFont, TGlyph> self,
       TypesettingContext<TFont, TGlyph> _,
       MathListIndex index) where TFont : IFont<TGlyph> =>
-      index.SubIndexType != MathListSubIndexType.None
+      index.SubIndexInfo is { }
       ? throw new ArgumentException
         ("The subindex must be none to get the closest point for it.", nameof(index))
       : index.AtomIndex == self.Range.End
@@ -46,7 +43,7 @@ namespace CSharpMath.Editor {
     public static void HighlightCharacterAt<TFont, TGlyph>(
       this LargeOpLimitsDisplay<TFont, TGlyph> self,
       MathListIndex index, Color color) where TFont : IFont<TGlyph> {
-      if (index.SubIndexType != MathListSubIndexType.None)
+      if (index.SubIndexInfo is { })
         throw new ArgumentException
           ("The subindex must be none to get the highlight a character in it.", nameof(index));
       self.Highlight(color);

--- a/CSharpMath/Editor/Extensions/LargeOpLimitsDisplay.cs
+++ b/CSharpMath/Editor/Extensions/LargeOpLimitsDisplay.cs
@@ -18,9 +18,9 @@ namespace CSharpMath.Editor {
       // We are after the large operator
       ? new(self.Range.End)
       : self.UpperLimit is { } u && point.Y > self.Position.Y + u.Position.Y - PixelDelta
-      ? u.IndexForPoint(context, point)?.WrapInIndex(self.Range.Location, MathListSubIndexType.Superscript)
+      ? u.IndexForPoint(context, point)?.Wrap(self.Range.Location, MathListSubIndexType.Superscript)
       : self.LowerLimit is { } l && point.Y < self.Position.Y + l.Position.Y + l.DisplayBounds().Height + PixelDelta
-      ? l.IndexForPoint(context, point)?.WrapInIndex(self.Range.Location, MathListSubIndexType.Subscript)
+      ? l.IndexForPoint(context, point)?.Wrap(self.Range.Location, MathListSubIndexType.Subscript)
       : point.X > self.Position.X + self.Width * 3 / 4
       ? new(self.Range.End)
       : point.X > self.Position.X + self.Width / 2

--- a/CSharpMath/Editor/Extensions/ListDisplay.cs
+++ b/CSharpMath/Editor/Extensions/ListDisplay.cs
@@ -84,7 +84,7 @@ namespace CSharpMath.Editor {
         if (closestLine.IndexInParent is int.MinValue)
           throw new ArgumentException
             ($"Index was not set for a {indexType} in the {nameof(ListDisplay<TFont, TGlyph>)}.", nameof(self));
-        return index?.WrapInIndex(closestLine.IndexInParent, indexType);
+        return index?.Wrap(closestLine.IndexInParent, indexType);
       } else if (displayWithPoint.HasScript)
         // The display list has a subscript or a superscript.
         // If the index is at the end of the atom,
@@ -108,7 +108,8 @@ namespace CSharpMath.Editor {
           (MathListSubIndexType.BetweenBaseAndScripts, var subIndex) => display.PointForIndex(context, new(index.AtomIndex + subIndex.AtomIndex)),
           null => display.PointForIndex(context, index),
           (_, var subIndex) => display.PointForIndex(context, subIndex) // Recurse
-        }; else
+        };
+      else
         // Outside the range
         return null;
       if (position is PointF found) {
@@ -166,7 +167,7 @@ namespace CSharpMath.Editor {
               ((MathListSubIndexType.Inner, _), InnerDisplay<TFont, TGlyph> inner) => inner.Inner,
               ((MathListSubIndexType.Superscript or MathListSubIndexType.Subscript, _), _) =>
                 throw new Atom.InvalidCodePathException("Superscripts and subscripts should have been handled in a separate case above."),
-              _ => throw new SubIndexTypeMismatchException(index),
+              ((var type, _), _) => throw new ArgumentOutOfRangeException(nameof(index), type, "Index type out of valid range."),
             };
       return null;
     }

--- a/CSharpMath/Editor/Extensions/ListDisplay.cs
+++ b/CSharpMath/Editor/Extensions/ListDisplay.cs
@@ -35,16 +35,13 @@ namespace CSharpMath.Editor {
         case 0:
           if (translatedPoint.X <= -PixelDelta)
             // All the way to the left
-            return self.Range.Location < 0
-                   ? null
-                   : MathListIndex.Level0Index(self.Range.Location);
+            return self.Range.Location < 0 ? null : new(self.Range.Location);
           else if (translatedPoint.X >= self.Width + PixelDelta) {
             // if closest is a script
-            if (closest is ListDisplay<TFont, TGlyph> ld && ld.LinePosition != LinePosition.Regular) {
+            if (closest is ListDisplay<TFont, TGlyph> { LinePosition: not LinePosition.Regular } ld) {
               // then we try to find its parent
-              var parent = self.Displays.FirstOrDefault(d => d.HasScript && d.Range.Contains(ld.IndexInParent));
-              if (parent != null) {
-                return MathListIndex.Level0Index(parent.Range.End);
+              if (self.Displays.FirstOrDefault(d => d.HasScript && d.Range.Contains(ld.IndexInParent)) is { } parent) {
+                return new(parent.Range.End);
               }
             }
             // All the way to the right
@@ -52,11 +49,10 @@ namespace CSharpMath.Editor {
               self.Range.End < 0
               ? null
               : self.Displays.Count == 1
-                && self.Displays[0] is TextLineDisplay<TFont, TGlyph> { Atoms: var atoms }
-                && atoms.Count == 1
+                && self.Displays[0] is TextLineDisplay<TFont, TGlyph> { Atoms: { Count: 1 } atoms }
                 && atoms[0] is Atom.Atoms.Placeholder
-              ? MathListIndex.Level0Index(self.Range.Location)
-              : MathListIndex.Level0Index(self.Range.End);
+              ? new(self.Range.Location)
+              : new(self.Range.End);
           } else
             // It is within the ListDisplay but not within the X bounds of any sublist.
             // Use the closest in that case.
@@ -88,14 +84,13 @@ namespace CSharpMath.Editor {
         if (closestLine.IndexInParent is int.MinValue)
           throw new ArgumentException
             ($"Index was not set for a {indexType} in the {nameof(ListDisplay<TFont, TGlyph>)}.", nameof(self));
-        return MathListIndex.IndexAtLocation(closestLine.IndexInParent, indexType, index);
+        return index?.WrapInIndex(closestLine.IndexInParent, indexType);
       } else if (displayWithPoint.HasScript)
         // The display list has a subscript or a superscript.
         // If the index is at the end of the atom,
         // then we need to put it before the sub/super script rather than after.
         if (index?.AtomIndex == displayWithPoint.Range.End)
-          return MathListIndex.IndexAtLocation
-            (index.AtomIndex - 1, MathListSubIndexType.BetweenBaseAndScripts, MathListIndex.Level0Index(1));
+          return new(index.AtomIndex - 1, new(MathListSubIndexType.BetweenBaseAndScripts, new(1)));
       return index;
     }
 
@@ -108,23 +103,12 @@ namespace CSharpMath.Editor {
       if (index.AtomIndex == self.Range.End) {
         // Special case the edge of the range
         position = new PointF(self.Width, 0);
-      } else if (self.Range.Contains(index.AtomIndex)
-                 && self.SubDisplayForIndex(index) is IDisplay<TFont, TGlyph> display)
-        switch (index.SubIndexType) {
-          case MathListSubIndexType.BetweenBaseAndScripts when index.SubIndex != null:
-            var nucleusPosition = index.AtomIndex + index.SubIndex.AtomIndex;
-            position = display.PointForIndex(context, MathListIndex.Level0Index(nucleusPosition));
-            break;
-          case MathListSubIndexType.None:
-            position = display.PointForIndex(context, index);
-            break;
-          case var _ when index.SubIndex != null:
-            // Recurse
-            position = display.PointForIndex(context, index.SubIndex);
-            break;
-          default:
-            throw new ArgumentException("index.Subindex is null despite a non-None subindex type");
-        } else
+      } else if (self.Range.Contains(index.AtomIndex) && self.SubDisplayForIndex(index) is { } display)
+        position = index.SubIndexInfo switch {
+          (MathListSubIndexType.BetweenBaseAndScripts, var subIndex) => display.PointForIndex(context, new(index.AtomIndex + subIndex.AtomIndex)),
+          null => display.PointForIndex(context, index),
+          (_, var subIndex) => display.PointForIndex(context, subIndex) // Recurse
+        }; else
         // Outside the range
         return null;
       if (position is PointF found) {
@@ -139,14 +123,12 @@ namespace CSharpMath.Editor {
 
     public static void HighlightCharacterAt<TFont, TGlyph>(this ListDisplay<TFont, TGlyph> self,
       MathListIndex index, Color color) where TFont : IFont<TGlyph> {
-      if (self.Range.Contains(index.AtomIndex)
-        && self.SubDisplayForIndex(index) is IDisplay<TFont, TGlyph> display)
-        if (index.SubIndexType is MathListSubIndexType.BetweenBaseAndScripts
-            || index.SubIndexType is MathListSubIndexType.None)
-          display.HighlightCharacterAt(index, color);
-        else if (index.SubIndex != null)
-          // Recurse
-          display.HighlightCharacterAt(index.SubIndex, color);
+      if (self.Range.Contains(index.AtomIndex) && self.SubDisplayForIndex(index) is { } display)
+        switch (index.SubIndexInfo) {
+          case (MathListSubIndexType.BetweenBaseAndScripts, _) or null: display.HighlightCharacterAt(index, color); break;
+          case (_, MathListIndex subIndex): display.HighlightCharacterAt(subIndex, color); break; // Recurse
+          default: break;
+        }
     }
 
     public static void Highlight<TFont, TGlyph>(this ListDisplay<TFont, TGlyph> self, Color color)
@@ -158,48 +140,34 @@ namespace CSharpMath.Editor {
     public static IDisplay<TFont, TGlyph>? SubDisplayForIndex<TFont, TGlyph>(
       this ListDisplay<TFont, TGlyph> self, MathListIndex index) where TFont : IFont<TGlyph> {
       // Inside the range
-      if (index.SubIndexType is MathListSubIndexType.Superscript
-         || index.SubIndexType is MathListSubIndexType.Subscript)
+      if (index.SubIndexInfo is (MathListSubIndexType.Superscript or MathListSubIndexType.Subscript, _))
         foreach (var display in self.Displays)
           switch (display) {
             case ListDisplay<TFont, TGlyph> list
               when index.AtomIndex == list.IndexInParent
               // This is the right character for the sub/superscript, check that it's type matches the index
-              && (list.LinePosition is LinePosition.Subscript
-               && index.SubIndexType is MathListSubIndexType.Subscript
-               || list.LinePosition is LinePosition.Superscript
-               && index.SubIndexType is MathListSubIndexType.Superscript):
+              && (list.LinePosition is LinePosition.Subscript && index.SubIndexInfo is (MathListSubIndexType.Subscript, _)
+                  || list.LinePosition is LinePosition.Superscript && index.SubIndexInfo is (MathListSubIndexType.Superscript, _)):
               return list;
             case LargeOpLimitsDisplay<TFont, TGlyph> largeOps
               when largeOps.Range.Contains(index.AtomIndex):
-              return index.SubIndexType is MathListSubIndexType.Subscript
-              ? largeOps.LowerLimit : largeOps.UpperLimit;
+              return index.SubIndexInfo is (MathListSubIndexType.Subscript, _) ? largeOps.LowerLimit : largeOps.UpperLimit;
           }
       else
         foreach (var display in self.Displays)
-          if (!(display is ListDisplay<TFont, TGlyph>) && display.Range.Contains(index.AtomIndex))
-            //not a subscript/superscript and ... jackpot, the the index is in the range of this atom.
-            switch (index.SubIndexType) {
-              case MathListSubIndexType.None:
-              case MathListSubIndexType.BetweenBaseAndScripts:
-                return display;
-              case MathListSubIndexType.Degree when display is RadicalDisplay<TFont, TGlyph> radical:
-                return radical.Degree;
-              case MathListSubIndexType.Radicand when display is RadicalDisplay<TFont, TGlyph> radical:
-                return radical.Radicand;
-              case MathListSubIndexType.Numerator when display is FractionDisplay<TFont, TGlyph> fraction:
-                return fraction.Numerator;
-              case MathListSubIndexType.Denominator when display is FractionDisplay<TFont, TGlyph> fraction:
-                return fraction.Denominator;
-              case MathListSubIndexType.Inner when display is InnerDisplay<TFont, TGlyph> inner:
-                return inner.Inner;
-              case MathListSubIndexType.Superscript:
-              case MathListSubIndexType.Subscript:
-                throw new Atom.InvalidCodePathException
-                  ("Superscripts and subscripts should have been handled in a separate case above.");
-              default:
-                throw new SubIndexTypeMismatchException(index);
-            }
+          if (display is not ListDisplay<TFont, TGlyph> && display.Range.Contains(index.AtomIndex))
+            // not a subscript/superscript and ... jackpot, the the index is in the range of this atom.
+            return (index.SubIndexInfo, display) switch {
+              (null or (MathListSubIndexType.BetweenBaseAndScripts, _), _) => display,
+              ((MathListSubIndexType.Degree, _), RadicalDisplay<TFont, TGlyph> radical) => radical.Degree,
+              ((MathListSubIndexType.Radicand, _), RadicalDisplay<TFont, TGlyph> radical) => radical.Radicand,
+              ((MathListSubIndexType.Numerator, _), FractionDisplay<TFont, TGlyph> fraction) => fraction.Numerator,
+              ((MathListSubIndexType.Denominator, _), FractionDisplay<TFont, TGlyph> fraction) => fraction.Denominator,
+              ((MathListSubIndexType.Inner, _), InnerDisplay<TFont, TGlyph> inner) => inner.Inner,
+              ((MathListSubIndexType.Superscript or MathListSubIndexType.Subscript, _), _) =>
+                throw new Atom.InvalidCodePathException("Superscripts and subscripts should have been handled in a separate case above."),
+              _ => throw new SubIndexTypeMismatchException(index),
+            };
       return null;
     }
   }

--- a/CSharpMath/Editor/Extensions/MathList.cs
+++ b/CSharpMath/Editor/Extensions/MathList.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Diagnostics.CodeAnalysis;
+
 
 namespace CSharpMath.Editor {
   using Atom;
@@ -68,7 +68,7 @@ namespace CSharpMath.Editor {
           throw new ArgumentOutOfRangeException(nameof(index), type, "Index type out of valid range.");
       }
     }
-    /// <summary>Removes the atom at <paramref name="index"/>, placing a new placeholder if all atoms removed, and returns a new <see cref="MathListIndex"/> with <paramref name="index"/> advanced to the next position indicated by <paramref name="advanceType"/>.</summary>
+    /// <summary>Removes the atom at <paramref name="index"/>, placing a new placeholder if all atoms are removed, and returns a new <see cref="MathListIndex"/> with <paramref name="index"/> advanced to the next appropriate position.</summary>
     public static MathListIndex RemoveAt(this MathList self, MathListIndex index) {
       if (index.AtomIndex > self.Atoms.Count)
         throw new IndexOutOfRangeException($"Index {index.AtomIndex} is out of bounds for list of size {self.Atoms.Count}");

--- a/CSharpMath/Editor/Extensions/MathList.cs
+++ b/CSharpMath/Editor/Extensions/MathList.cs
@@ -25,11 +25,11 @@ namespace CSharpMath.Editor {
         throw new IndexOutOfRangeException($"Index {index.AtomIndex} is out of bounds for list of size {self.Atoms.Count}");
       switch (index.SubIndexInfo) {
         case null:
-          return self.InsertAtAtomIndexAndAdvance(index.AtomIndex, atom, index, null);
+          return self.InsertAtAtomIndexAndAdvance(index.AtomIndex, atom, index, advanceType);
         case (MathListSubIndexType.BetweenBaseAndScripts, _):
           var currentAtom = self.Atoms[index.AtomIndex];
           if (currentAtom.Subscript.IsEmpty() && currentAtom.Superscript.IsEmpty())
-            throw new SubIndexTypeMismatchException(index);
+            throw new SubIndexTypeMismatchException(nameof(MathListSubIndexType.BetweenBaseAndScripts), index.AtomIndex);
           if (atom.Subscript.IsNonEmpty() || atom.Superscript.IsNonEmpty())
             throw new ArgumentException("Cannot fuse with an atom that already has a subscript or a superscript");
           atom.Subscript.Append(currentAtom.Subscript);
@@ -42,30 +42,30 @@ namespace CSharpMath.Editor {
           return self.InsertAtAtomIndexAndAdvance(atomIndex + 1, atom, index, advanceType);
         case (MathListSubIndexType.Degree, var subIndex)
           when self.Atoms[index.AtomIndex] is Atoms.Radical radical ? true
-               : throw new SubIndexTypeMismatchException(typeof(Atoms.Radical), index):
-          return radical.Degree.InsertAndAdvance(subIndex, atom, advanceType).WrapInIndex(index.AtomIndex, MathListSubIndexType.Degree);
+               : throw new SubIndexTypeMismatchException(nameof(Atoms.Radical), index.AtomIndex):
+          return radical.Degree.InsertAndAdvance(subIndex, atom, advanceType).Wrap(index.AtomIndex, MathListSubIndexType.Degree);
         case (MathListSubIndexType.Radicand, var subIndex)
           when self.Atoms[index.AtomIndex] is Atoms.Radical radical ? true
-               : throw new SubIndexTypeMismatchException(typeof(Atoms.Radical), index):
-          return radical.Degree.InsertAndAdvance(subIndex, atom, advanceType).WrapInIndex(index.AtomIndex, MathListSubIndexType.Radicand);
+               : throw new SubIndexTypeMismatchException(nameof(Atoms.Radical), index.AtomIndex):
+          return radical.Radicand.InsertAndAdvance(subIndex, atom, advanceType).Wrap(index.AtomIndex, MathListSubIndexType.Radicand);
         case (MathListSubIndexType.Numerator, var subIndex)
           when self.Atoms[index.AtomIndex] is Atoms.Fraction frac ? true
-               : throw new SubIndexTypeMismatchException(typeof(Atoms.Fraction), index):
-          return frac.Numerator.InsertAndAdvance(subIndex, atom, advanceType).WrapInIndex(index.AtomIndex, MathListSubIndexType.Numerator);
+               : throw new SubIndexTypeMismatchException(nameof(Atoms.Fraction), index.AtomIndex):
+          return frac.Numerator.InsertAndAdvance(subIndex, atom, advanceType).Wrap(index.AtomIndex, MathListSubIndexType.Numerator);
         case (MathListSubIndexType.Denominator, var subIndex)
           when self.Atoms[index.AtomIndex] is Atoms.Fraction frac ? true
-               : throw new SubIndexTypeMismatchException(typeof(Atoms.Fraction), index):
-          return frac.Denominator.InsertAndAdvance(subIndex, atom, advanceType).WrapInIndex(index.AtomIndex, MathListSubIndexType.Denominator);
+               : throw new SubIndexTypeMismatchException(nameof(Atoms.Fraction), index.AtomIndex):
+          return frac.Denominator.InsertAndAdvance(subIndex, atom, advanceType).Wrap(index.AtomIndex, MathListSubIndexType.Denominator);
         case (MathListSubIndexType.Subscript, var subIndex):
-          return self.Atoms[index.AtomIndex].Subscript.InsertAndAdvance(subIndex, atom, advanceType).WrapInIndex(index.AtomIndex, MathListSubIndexType.Subscript);
+          return self.Atoms[index.AtomIndex].Subscript.InsertAndAdvance(subIndex, atom, advanceType).Wrap(index.AtomIndex, MathListSubIndexType.Subscript);
         case (MathListSubIndexType.Superscript, var subIndex):
-          return self.Atoms[index.AtomIndex].Superscript.InsertAndAdvance(subIndex, atom, advanceType).WrapInIndex(index.AtomIndex, MathListSubIndexType.Superscript);
+          return self.Atoms[index.AtomIndex].Superscript.InsertAndAdvance(subIndex, atom, advanceType).Wrap(index.AtomIndex, MathListSubIndexType.Superscript);
         case (MathListSubIndexType.Inner, var subIndex)
           when self.Atoms[index.AtomIndex] is Atoms.Inner inner ? true
-               : throw new SubIndexTypeMismatchException(typeof(Atoms.Fraction), index):
-          return inner.InnerList.InsertAndAdvance(subIndex, atom, advanceType).WrapInIndex(index.AtomIndex, MathListSubIndexType.Inner);
-        default:
-          throw new SubIndexTypeMismatchException(index);
+               : throw new SubIndexTypeMismatchException(nameof(Atoms.Inner), index.AtomIndex):
+          return inner.InnerList.InsertAndAdvance(subIndex, atom, advanceType).Wrap(index.AtomIndex, MathListSubIndexType.Inner);
+        case (var type, _):
+          throw new ArgumentOutOfRangeException(nameof(index), type, "Index type out of valid range.");
       }
     }
     /// <summary>Removes the atom at <paramref name="index"/>, placing a new placeholder if all atoms removed, and returns a new <see cref="MathListIndex"/> with <paramref name="index"/> advanced to the next position indicated by <paramref name="advanceType"/>.</summary>
@@ -79,7 +79,7 @@ namespace CSharpMath.Editor {
         case (MathListSubIndexType.BetweenBaseAndScripts, _):
           var currentAtom = self.Atoms[index.AtomIndex];
           if (currentAtom.Subscript.IsEmpty() && currentAtom.Superscript.IsEmpty())
-            throw new SubIndexTypeMismatchException(index);
+            throw new SubIndexTypeMismatchException(nameof(MathListSubIndexType.BetweenBaseAndScripts), index.AtomIndex);
           var downIndex = index.LevelDown() ?? throw new InvalidCodePathException("downIndex is null");
           if (index.AtomIndex > 0 &&
               self.Atoms[index.AtomIndex - 1] is MathAtom previous &&
@@ -112,43 +112,43 @@ namespace CSharpMath.Editor {
           return index.Previous ?? throw new InvalidCodePathException("Cannot go back after insertion?");
         case (MathListSubIndexType.Degree, var subIndex)
           when self.Atoms[index.AtomIndex] is Atoms.Radical radical ? true
-               : throw new SubIndexTypeMismatchException(typeof(Atoms.Radical), index):
-          index = radical.Degree.RemoveAt(subIndex).WrapInIndex(index.AtomIndex, MathListSubIndexType.Degree);
+               : throw new SubIndexTypeMismatchException(nameof(Atoms.Radical), index.AtomIndex):
+          index = radical.Degree.RemoveAt(subIndex).Wrap(index.AtomIndex, MathListSubIndexType.Degree);
           break;
         case (MathListSubIndexType.Radicand, var subIndex)
           when self.Atoms[index.AtomIndex] is Atoms.Radical radical ? true
-               : throw new SubIndexTypeMismatchException(typeof(Atoms.Radical), index):
-          index = radical.Radicand.RemoveAt(subIndex).WrapInIndex(index.AtomIndex, MathListSubIndexType.Radicand);
+               : throw new SubIndexTypeMismatchException(nameof(Atoms.Radical), index.AtomIndex):
+          index = radical.Radicand.RemoveAt(subIndex).Wrap(index.AtomIndex, MathListSubIndexType.Radicand);
           break;
         case (MathListSubIndexType.Numerator, var subIndex)
           when self.Atoms[index.AtomIndex] is Atoms.Fraction frac ? true
-               : throw new SubIndexTypeMismatchException(typeof(Atoms.Fraction), index):
-          index = frac.Numerator.RemoveAt(subIndex).WrapInIndex(index.AtomIndex, MathListSubIndexType.Numerator);
+               : throw new SubIndexTypeMismatchException(nameof(Atoms.Fraction), index.AtomIndex):
+          index = frac.Numerator.RemoveAt(subIndex).Wrap(index.AtomIndex, MathListSubIndexType.Numerator);
           break;
         case (MathListSubIndexType.Denominator, var subIndex)
           when self.Atoms[index.AtomIndex] is Atoms.Fraction frac ? true
-               : throw new SubIndexTypeMismatchException(typeof(Atoms.Fraction), index):
-          index = frac.Denominator.RemoveAt(subIndex).WrapInIndex(index.AtomIndex, MathListSubIndexType.Denominator);
+               : throw new SubIndexTypeMismatchException(nameof(Atoms.Fraction), index.AtomIndex):
+          index = frac.Denominator.RemoveAt(subIndex).Wrap(index.AtomIndex, MathListSubIndexType.Denominator);
           break;
         case (MathListSubIndexType.Subscript, var subIndex):
           var current = self.Atoms[index.AtomIndex];
           if (current.Subscript.IsEmpty())
-            throw new SubIndexTypeMismatchException(index);
-          index = current.Subscript.RemoveAt(subIndex).WrapInIndex(index.AtomIndex, MathListSubIndexType.Subscript);
+            throw new SubIndexTypeMismatchException(nameof(MathListSubIndexType.Subscript), index.AtomIndex);
+          index = current.Subscript.RemoveAt(subIndex).Wrap(index.AtomIndex, MathListSubIndexType.Subscript);
           break;
         case (MathListSubIndexType.Superscript, var subIndex):
           current = self.Atoms[index.AtomIndex];
           if (current.Superscript.IsEmpty())
-            throw new SubIndexTypeMismatchException(index);
-          index = current.Superscript.RemoveAt(subIndex).WrapInIndex(index.AtomIndex, MathListSubIndexType.Superscript);
+            throw new SubIndexTypeMismatchException(nameof(MathListSubIndexType.Superscript), index.AtomIndex);
+          index = current.Superscript.RemoveAt(subIndex).Wrap(index.AtomIndex, MathListSubIndexType.Superscript);
           break;
         case (MathListSubIndexType.Inner, var subIndex)
           when self.Atoms[index.AtomIndex] is Atoms.Inner inner ? true
-               : throw new SubIndexTypeMismatchException(typeof(Atoms.Inner), index):
-          index = inner.InnerList.RemoveAt(subIndex).WrapInIndex(index.AtomIndex, MathListSubIndexType.Inner);
+               : throw new SubIndexTypeMismatchException(nameof(Atoms.Inner), index.AtomIndex):
+          index = inner.InnerList.RemoveAt(subIndex).Wrap(index.AtomIndex, MathListSubIndexType.Inner);
           break;
-        default:
-          throw new SubIndexTypeMismatchException(index);
+        case (var type, _):
+          throw new ArgumentOutOfRangeException(nameof(index), type, "Index type out of valid range.");
       }
       if (index.Previous is null && index.SubIndexInfo is { })
         // We have deleted to the beginning of the line and it is not the outermost line
@@ -168,37 +168,37 @@ namespace CSharpMath.Editor {
           throw new NotSupportedException("Nuclear fission is not supported");
         case (MathListSubIndexType.Degree, _)
           when self.Atoms[start.AtomIndex] is Atoms.Radical radical ? true
-               : throw new SubIndexTypeMismatchException(typeof(Atoms.Radical), start):
+               : throw new SubIndexTypeMismatchException(nameof(Atoms.Radical), start.AtomIndex):
           radical.Degree.RemoveAtoms(range.SubIndexRange);
           break;
         case (MathListSubIndexType.Radicand, _)
           when self.Atoms[start.AtomIndex] is Atoms.Radical radical ? true
-               : throw new SubIndexTypeMismatchException(typeof(Atoms.Radical), start):
+               : throw new SubIndexTypeMismatchException(nameof(Atoms.Radical), start.AtomIndex):
           radical.Radicand.RemoveAtoms(range.SubIndexRange);
           break;
         case (MathListSubIndexType.Numerator, _)
           when self.Atoms[start.AtomIndex] is Atoms.Fraction frac ? true
-               : throw new SubIndexTypeMismatchException(typeof(Atoms.Fraction), start):
+               : throw new SubIndexTypeMismatchException(nameof(Atoms.Fraction), start.AtomIndex):
           frac.Numerator.RemoveAtoms(range.SubIndexRange);
           break;
-        case (MathListSubIndexType.Radicand, _)
+        case (MathListSubIndexType.Denominator, _)
           when self.Atoms[start.AtomIndex] is Atoms.Fraction frac ? true
-               : throw new SubIndexTypeMismatchException(typeof(Atoms.Fraction), start):
+               : throw new SubIndexTypeMismatchException(nameof(Atoms.Fraction), start.AtomIndex):
           frac.Denominator.RemoveAtoms(range.SubIndexRange);
           break;
         case (MathListSubIndexType.Subscript, _):
           var current = self.Atoms[start.AtomIndex];
-          if (current.Subscript.IsEmpty()) throw new SubIndexTypeMismatchException(start);
+          if (current.Subscript.IsEmpty()) throw new SubIndexTypeMismatchException(nameof(MathListSubIndexType.Subscript), start.AtomIndex);
           current.Subscript.RemoveAtoms(range.SubIndexRange);
           break;
         case (MathListSubIndexType.Superscript, _):
           current = self.Atoms[start.AtomIndex];
-          if (current.Superscript.IsEmpty()) throw new SubIndexTypeMismatchException(start);
+          if (current.Superscript.IsEmpty()) throw new SubIndexTypeMismatchException(nameof(MathListSubIndexType.Superscript), start.AtomIndex);
           current.Superscript.RemoveAtoms(range.SubIndexRange);
           break;
         case (MathListSubIndexType.Inner, _)
           when self.Atoms[start.AtomIndex] is Atoms.Inner inner ? true
-               : throw new SubIndexTypeMismatchException(typeof(Atoms.Fraction), start):
+               : throw new SubIndexTypeMismatchException(nameof(Atoms.Inner), start.AtomIndex):
           inner.InnerList.RemoveAtoms(range.SubIndexRange);
           break;
       }
@@ -217,7 +217,7 @@ namespace CSharpMath.Editor {
         (MathListSubIndexType.Numerator, var subIndex) => atom is Atoms.Fraction frac ? frac.Numerator.AtomAt(subIndex) : null,
         (MathListSubIndexType.Denominator, var subIndex) => atom is Atoms.Fraction frac ? frac.Denominator.AtomAt(subIndex) : null,
         (MathListSubIndexType.Inner, var subIndex) => atom is Atoms.Inner inner ? inner.InnerList.AtomAt(subIndex) : null,
-        _ => throw new SubIndexTypeMismatchException(index),
+        (var type, _) => throw new ArgumentOutOfRangeException(nameof(index), type, "Index type out of valid range."),
       };
     }
   }

--- a/CSharpMath/Editor/Extensions/MathList.cs
+++ b/CSharpMath/Editor/Extensions/MathList.cs
@@ -1,10 +1,11 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace CSharpMath.Editor {
   using Atom;
   using Atoms = Atom.Atoms;
   partial class Extensions {
-    static void InsertAtAtomIndexAndAdvance(this MathList self, int atomIndex, MathAtom atom, ref MathListIndex advance, MathListSubIndexType advanceType) {
+    static MathListIndex InsertAtAtomIndexAndAdvance(this MathList self, int atomIndex, MathAtom atom, MathListIndex advance, MathListSubIndexType? advanceType) {
       if (atomIndex < 0 || atomIndex > self.Count)
         throw new IndexOutOfRangeException($"Index {atomIndex} is out of bounds for list of size {self.Atoms.Count}");
       // Test for placeholder to the right of index, e.g. \sqrt{‸■} -> \sqrt{2‸}
@@ -13,23 +14,19 @@ namespace CSharpMath.Editor {
         atom.Subscript.Append(placeholder.Subscript);
         self[atomIndex] = atom;
       } else self.Insert(atomIndex, atom);
-      advance = advanceType switch {
-        MathListSubIndexType.None => advance.Next,
-        _ => advance.LevelUpWithSubIndex(advanceType, MathListIndex.Level0Index(0)),
+      return advanceType switch {
+        { } a => advance.LevelUpWithSubIndex(a, 0),
+        null => advance.Next,
       };
     }
-    /// <summary>Inserts <paramref name="atom"/> and modifies <paramref name="index"/> to advance to the next position.</summary>
-    public static void InsertAndAdvance(this MathList self, ref MathListIndex index, MathAtom atom, MathListSubIndexType advanceType) {
-      index ??= MathListIndex.Level0Index(0);
+    /// <summary>Inserts <paramref name="atom"/> and returns a new <see cref="MathListIndex"/> with <paramref name="index"/> advanced to the next position which is another subindex level if <paramref name="advanceType"/> is not <see langword="null"/>.</summary>
+    public static MathListIndex InsertAndAdvance(this MathList self, MathListIndex index, MathAtom atom, MathListSubIndexType? advanceType) {
       if (index.AtomIndex > self.Atoms.Count)
         throw new IndexOutOfRangeException($"Index {index.AtomIndex} is out of bounds for list of size {self.Atoms.Count}");
-      switch (index.SubIndexType) {
-        case MathListSubIndexType.None:
-          self.InsertAtAtomIndexAndAdvance(index.AtomIndex, atom, ref index, advanceType);
-          break;
-        case var _ when index.SubIndex is null:
-          throw new InvalidCodePathException("index.SubIndex is null despite non-None subindex type");
-        case MathListSubIndexType.BetweenBaseAndScripts:
+      switch (index.SubIndexInfo) {
+        case null:
+          return self.InsertAtAtomIndexAndAdvance(index.AtomIndex, atom, index, null);
+        case (MathListSubIndexType.BetweenBaseAndScripts, _):
           var currentAtom = self.Atoms[index.AtomIndex];
           if (currentAtom.Subscript.IsEmpty() && currentAtom.Superscript.IsEmpty())
             throw new SubIndexTypeMismatchException(index);
@@ -41,59 +38,49 @@ namespace CSharpMath.Editor {
           currentAtom.Superscript.Clear();
           var atomIndex = index.AtomIndex;
           // Prevent further subindexing inside BetweenBaseAndScripts
-          if (advanceType != MathListSubIndexType.None
-              && index.LevelDown() is MathListIndex levelDown) index = levelDown.Next;
-          self.InsertAtAtomIndexAndAdvance(atomIndex + 1, atom, ref index, advanceType);
-          break;
-        case MathListSubIndexType.Degree:
-        case MathListSubIndexType.Radicand:
-          if (!(self.Atoms[index.AtomIndex] is Atoms.Radical radical))
-            throw new SubIndexTypeMismatchException(typeof(Atoms.Radical), index);
-          if (index.SubIndexType == MathListSubIndexType.Degree)
-            radical.Degree.InsertAndAdvance(ref index.SubIndex, atom, advanceType);
-          else radical.Radicand.InsertAndAdvance(ref index.SubIndex, atom, advanceType);
-          break;
-        case MathListSubIndexType.Numerator:
-        case MathListSubIndexType.Denominator:
-          if (!(self.Atoms[index.AtomIndex] is Atoms.Fraction frac))
-            throw new SubIndexTypeMismatchException(typeof(Atoms.Fraction), index);
-          if (index.SubIndexType == MathListSubIndexType.Numerator)
-            frac.Numerator.InsertAndAdvance(ref index.SubIndex, atom, advanceType);
-          else
-            frac.Denominator.InsertAndAdvance(ref index.SubIndex, atom, advanceType);
-          break;
-        case MathListSubIndexType.Subscript:
-          self.Atoms[index.AtomIndex].Subscript.InsertAndAdvance(ref index.SubIndex, atom, advanceType);
-          break;
-        case MathListSubIndexType.Superscript:
-          self.Atoms[index.AtomIndex].Superscript.InsertAndAdvance(ref index.SubIndex, atom, advanceType);
-          break;
-        case MathListSubIndexType.Inner:
-          if (!(self.Atoms[index.AtomIndex] is Atoms.Inner inner))
-            throw new SubIndexTypeMismatchException(typeof(Atoms.Inner), index);
-          inner.InnerList.InsertAndAdvance(ref index.SubIndex, atom, advanceType);
-          break;
+          if (advanceType is { } && index.LevelDown() is MathListIndex levelDown) index = levelDown.Next;
+          return self.InsertAtAtomIndexAndAdvance(atomIndex + 1, atom, index, advanceType);
+        case (MathListSubIndexType.Degree, var subIndex)
+          when self.Atoms[index.AtomIndex] is Atoms.Radical radical ? true
+               : throw new SubIndexTypeMismatchException(typeof(Atoms.Radical), index):
+          return radical.Degree.InsertAndAdvance(subIndex, atom, advanceType).WrapInIndex(index.AtomIndex, MathListSubIndexType.Degree);
+        case (MathListSubIndexType.Radicand, var subIndex)
+          when self.Atoms[index.AtomIndex] is Atoms.Radical radical ? true
+               : throw new SubIndexTypeMismatchException(typeof(Atoms.Radical), index):
+          return radical.Degree.InsertAndAdvance(subIndex, atom, advanceType).WrapInIndex(index.AtomIndex, MathListSubIndexType.Radicand);
+        case (MathListSubIndexType.Numerator, var subIndex)
+          when self.Atoms[index.AtomIndex] is Atoms.Fraction frac ? true
+               : throw new SubIndexTypeMismatchException(typeof(Atoms.Fraction), index):
+          return frac.Numerator.InsertAndAdvance(subIndex, atom, advanceType).WrapInIndex(index.AtomIndex, MathListSubIndexType.Numerator);
+        case (MathListSubIndexType.Denominator, var subIndex)
+          when self.Atoms[index.AtomIndex] is Atoms.Fraction frac ? true
+               : throw new SubIndexTypeMismatchException(typeof(Atoms.Fraction), index):
+          return frac.Denominator.InsertAndAdvance(subIndex, atom, advanceType).WrapInIndex(index.AtomIndex, MathListSubIndexType.Denominator);
+        case (MathListSubIndexType.Subscript, var subIndex):
+          return self.Atoms[index.AtomIndex].Subscript.InsertAndAdvance(subIndex, atom, advanceType).WrapInIndex(index.AtomIndex, MathListSubIndexType.Subscript);
+        case (MathListSubIndexType.Superscript, var subIndex):
+          return self.Atoms[index.AtomIndex].Superscript.InsertAndAdvance(subIndex, atom, advanceType).WrapInIndex(index.AtomIndex, MathListSubIndexType.Superscript);
+        case (MathListSubIndexType.Inner, var subIndex)
+          when self.Atoms[index.AtomIndex] is Atoms.Inner inner ? true
+               : throw new SubIndexTypeMismatchException(typeof(Atoms.Fraction), index):
+          return inner.InnerList.InsertAndAdvance(subIndex, atom, advanceType).WrapInIndex(index.AtomIndex, MathListSubIndexType.Inner);
         default:
           throw new SubIndexTypeMismatchException(index);
       }
     }
-
-    public static void RemoveAt(this MathList self, ref MathListIndex index) {
-      index ??= MathListIndex.Level0Index(0);
+    /// <summary>Removes the atom at <paramref name="index"/>, placing a new placeholder if all atoms removed, and returns a new <see cref="MathListIndex"/> with <paramref name="index"/> advanced to the next position indicated by <paramref name="advanceType"/>.</summary>
+    public static MathListIndex RemoveAt(this MathList self, MathListIndex index) {
       if (index.AtomIndex > self.Atoms.Count)
         throw new IndexOutOfRangeException($"Index {index.AtomIndex} is out of bounds for list of size {self.Atoms.Count}");
-      switch (index.SubIndexType) {
-        case MathListSubIndexType.None:
+      switch (index.SubIndexInfo) {
+        case null:
           self.RemoveAt(index.AtomIndex);
           break;
-        case var _ when index.SubIndex is null:
-          throw new InvalidCodePathException("index.SubIndex is null despite non-None subindex type");
-        case MathListSubIndexType.BetweenBaseAndScripts:
+        case (MathListSubIndexType.BetweenBaseAndScripts, _):
           var currentAtom = self.Atoms[index.AtomIndex];
           if (currentAtom.Subscript.IsEmpty() && currentAtom.Superscript.IsEmpty())
             throw new SubIndexTypeMismatchException(index);
-          var downIndex = index.LevelDown();
-          if (downIndex is null) throw new InvalidCodePathException("downIndex is null");
+          var downIndex = index.LevelDown() ?? throw new InvalidCodePathException("downIndex is null");
           if (index.AtomIndex > 0 &&
               self.Atoms[index.AtomIndex - 1] is MathAtom previous &&
               previous.Subscript.IsEmpty() &&
@@ -111,7 +98,7 @@ namespace CSharpMath.Editor {
             self.RemoveAt(index.AtomIndex);
             // it was in the nucleus and we removed it, get out of the nucleus and get in the nucleus of the previous one.
             index = downIndex.Previous is MathListIndex downPrev
-              ? downPrev.LevelUpWithSubIndex(MathListSubIndexType.BetweenBaseAndScripts, MathListIndex.Level0Index(1))
+              ? downPrev.LevelUpWithSubIndex(MathListSubIndexType.BetweenBaseAndScripts, 1)
               : downIndex;
             break;
           }
@@ -121,94 +108,97 @@ namespace CSharpMath.Editor {
           insertionAtom.Superscript.Append(currentAtom.Superscript);
           self.RemoveAt(index.AtomIndex);
           index = downIndex;
-          self.InsertAndAdvance(ref index, insertionAtom, MathListSubIndexType.None);
-          index = index.Previous ?? throw new InvalidCodePathException("Cannot go back after insertion?");
-          return;
-        case MathListSubIndexType.Radicand:
-        case MathListSubIndexType.Degree:
-          if (!(self.Atoms[index.AtomIndex] is Atoms.Radical radical))
-            throw new SubIndexTypeMismatchException(typeof(Atoms.Radical), index);
-          if (index.SubIndexType == MathListSubIndexType.Degree)
-            radical.Degree.RemoveAt(ref index.SubIndex);
-          else radical.Radicand.RemoveAt(ref index.SubIndex);
+          index = self.InsertAndAdvance(index, insertionAtom, null);
+          return index.Previous ?? throw new InvalidCodePathException("Cannot go back after insertion?");
+        case (MathListSubIndexType.Degree, var subIndex)
+          when self.Atoms[index.AtomIndex] is Atoms.Radical radical ? true
+               : throw new SubIndexTypeMismatchException(typeof(Atoms.Radical), index):
+          index = radical.Degree.RemoveAt(subIndex).WrapInIndex(index.AtomIndex, MathListSubIndexType.Degree);
           break;
-        case MathListSubIndexType.Numerator:
-        case MathListSubIndexType.Denominator:
-          if (!(self.Atoms[index.AtomIndex] is Atoms.Fraction frac))
-            throw new SubIndexTypeMismatchException(typeof(Atoms.Fraction), index);
-          if (index.SubIndexType == MathListSubIndexType.Numerator)
-            frac.Numerator.RemoveAt(ref index.SubIndex);
-          else frac.Denominator.RemoveAt(ref index.SubIndex);
+        case (MathListSubIndexType.Radicand, var subIndex)
+          when self.Atoms[index.AtomIndex] is Atoms.Radical radical ? true
+               : throw new SubIndexTypeMismatchException(typeof(Atoms.Radical), index):
+          index = radical.Radicand.RemoveAt(subIndex).WrapInIndex(index.AtomIndex, MathListSubIndexType.Radicand);
           break;
-        case MathListSubIndexType.Subscript:
+        case (MathListSubIndexType.Numerator, var subIndex)
+          when self.Atoms[index.AtomIndex] is Atoms.Fraction frac ? true
+               : throw new SubIndexTypeMismatchException(typeof(Atoms.Fraction), index):
+          index = frac.Numerator.RemoveAt(subIndex).WrapInIndex(index.AtomIndex, MathListSubIndexType.Numerator);
+          break;
+        case (MathListSubIndexType.Denominator, var subIndex)
+          when self.Atoms[index.AtomIndex] is Atoms.Fraction frac ? true
+               : throw new SubIndexTypeMismatchException(typeof(Atoms.Fraction), index):
+          index = frac.Denominator.RemoveAt(subIndex).WrapInIndex(index.AtomIndex, MathListSubIndexType.Denominator);
+          break;
+        case (MathListSubIndexType.Subscript, var subIndex):
           var current = self.Atoms[index.AtomIndex];
           if (current.Subscript.IsEmpty())
             throw new SubIndexTypeMismatchException(index);
-          current.Subscript.RemoveAt(ref index.SubIndex);
+          index = current.Subscript.RemoveAt(subIndex).WrapInIndex(index.AtomIndex, MathListSubIndexType.Subscript);
           break;
-        case MathListSubIndexType.Superscript:
+        case (MathListSubIndexType.Superscript, var subIndex):
           current = self.Atoms[index.AtomIndex];
           if (current.Superscript.IsEmpty())
             throw new SubIndexTypeMismatchException(index);
-          current.Superscript.RemoveAt(ref index.SubIndex);
+          index = current.Superscript.RemoveAt(subIndex).WrapInIndex(index.AtomIndex, MathListSubIndexType.Superscript);
           break;
-        case MathListSubIndexType.Inner:
-          if (!(self.Atoms[index.AtomIndex] is Atoms.Inner inner))
-            throw new SubIndexTypeMismatchException(typeof(Atoms.Inner), index);
-          inner.InnerList.RemoveAt(ref index.SubIndex);
+        case (MathListSubIndexType.Inner, var subIndex)
+          when self.Atoms[index.AtomIndex] is Atoms.Inner inner ? true
+               : throw new SubIndexTypeMismatchException(typeof(Atoms.Inner), index):
+          index = inner.InnerList.RemoveAt(subIndex).WrapInIndex(index.AtomIndex, MathListSubIndexType.Inner);
           break;
         default:
           throw new SubIndexTypeMismatchException(index);
       }
-      if (index.Previous is null && index.SubIndexType != MathListSubIndexType.None) {
+      if (index.Previous is null && index.SubIndexInfo is { })
         // We have deleted to the beginning of the line and it is not the outermost line
-        if (self.AtomAt(index) is null) {
-          self.InsertAndAdvance(ref index, LaTeXSettings.Placeholder, MathListSubIndexType.None);
-          index = index.Previous ?? throw new InvalidCodePathException("Cannot go back after insertion?"); ;
-        }
-      }
+        if (self.AtomAt(index) is null)
+          self.InsertAndAdvance(index, LaTeXSettings.Placeholder, null);
+      return index;
     }
 
     public static void RemoveAtoms(this MathList self, MathListRange? nullableRange) {
-      if (!(nullableRange is MathListRange range)) return;
+      if (nullableRange is not MathListRange range) return;
       var start = range.Start;
-      switch (start.SubIndexType) {
-        case MathListSubIndexType.None:
+      switch (start.SubIndexInfo) {
+        case null:
           self.RemoveAtoms(start.AtomIndex, range.Length);
           break;
-        case var _ when start.SubIndex is null:
-          throw new InvalidCodePathException("start.SubIndex is null despite non-None subindex type");
-        case MathListSubIndexType.BetweenBaseAndScripts:
+        case (MathListSubIndexType.BetweenBaseAndScripts, _):
           throw new NotSupportedException("Nuclear fission is not supported");
-        case MathListSubIndexType.Radicand:
-        case MathListSubIndexType.Degree:
-          if (!(self.Atoms[start.AtomIndex] is Atoms.Radical radical))
-            throw new SubIndexTypeMismatchException(typeof(Atoms.Radical), start);
-          if (start.SubIndexType == MathListSubIndexType.Degree)
-            radical.Degree.RemoveAtoms(range.SubIndexRange);
-          else radical.Radicand.RemoveAtoms(range.SubIndexRange);
+        case (MathListSubIndexType.Degree, _)
+          when self.Atoms[start.AtomIndex] is Atoms.Radical radical ? true
+               : throw new SubIndexTypeMismatchException(typeof(Atoms.Radical), start):
+          radical.Degree.RemoveAtoms(range.SubIndexRange);
           break;
-        case MathListSubIndexType.Numerator:
-        case MathListSubIndexType.Denominator:
-          if (!(self.Atoms[start.AtomIndex] is Atoms.Fraction frac))
-            throw new SubIndexTypeMismatchException(typeof(Atoms.Fraction), start);
-          if (start.SubIndexType == MathListSubIndexType.Numerator)
-            frac.Numerator.RemoveAtoms(range.SubIndexRange);
-          else frac.Denominator.RemoveAtoms(range.SubIndexRange);
+        case (MathListSubIndexType.Radicand, _)
+          when self.Atoms[start.AtomIndex] is Atoms.Radical radical ? true
+               : throw new SubIndexTypeMismatchException(typeof(Atoms.Radical), start):
+          radical.Radicand.RemoveAtoms(range.SubIndexRange);
           break;
-        case MathListSubIndexType.Subscript:
+        case (MathListSubIndexType.Numerator, _)
+          when self.Atoms[start.AtomIndex] is Atoms.Fraction frac ? true
+               : throw new SubIndexTypeMismatchException(typeof(Atoms.Fraction), start):
+          frac.Numerator.RemoveAtoms(range.SubIndexRange);
+          break;
+        case (MathListSubIndexType.Radicand, _)
+          when self.Atoms[start.AtomIndex] is Atoms.Fraction frac ? true
+               : throw new SubIndexTypeMismatchException(typeof(Atoms.Fraction), start):
+          frac.Denominator.RemoveAtoms(range.SubIndexRange);
+          break;
+        case (MathListSubIndexType.Subscript, _):
           var current = self.Atoms[start.AtomIndex];
           if (current.Subscript.IsEmpty()) throw new SubIndexTypeMismatchException(start);
           current.Subscript.RemoveAtoms(range.SubIndexRange);
           break;
-        case MathListSubIndexType.Superscript:
+        case (MathListSubIndexType.Superscript, _):
           current = self.Atoms[start.AtomIndex];
           if (current.Superscript.IsEmpty()) throw new SubIndexTypeMismatchException(start);
           current.Superscript.RemoveAtoms(range.SubIndexRange);
           break;
-        case MathListSubIndexType.Inner:
-          if (!(self.Atoms[start.AtomIndex] is Atoms.Inner inner))
-            throw new SubIndexTypeMismatchException(typeof(Atoms.Inner), start);
+        case (MathListSubIndexType.Inner, _)
+          when self.Atoms[start.AtomIndex] is Atoms.Inner inner ? true
+               : throw new SubIndexTypeMismatchException(typeof(Atoms.Fraction), start):
           inner.InnerList.RemoveAtoms(range.SubIndexRange);
           break;
       }
@@ -217,38 +207,18 @@ namespace CSharpMath.Editor {
     public static MathAtom? AtomAt(this MathList self, MathListIndex? index) {
       if (index is null || index.AtomIndex >= self.Atoms.Count) return null;
       var atom = self.Atoms[index.AtomIndex];
-      switch (index.SubIndexType) {
-        case MathListSubIndexType.None:
-          return atom;
-        case var _ when index.SubIndex is null:
-          throw new InvalidCodePathException("index.SubIndex is null despite non-None subindex type");
-        case MathListSubIndexType.BetweenBaseAndScripts:
-          return null;
-        case MathListSubIndexType.Subscript:
-          return atom.Subscript.AtomAt(index.SubIndex);
-        case MathListSubIndexType.Superscript:
-          return atom.Superscript.AtomAt(index.SubIndex);
-        case MathListSubIndexType.Radicand:
-        case MathListSubIndexType.Degree:
-          return
-            atom is Atoms.Radical radical
-            ? index.SubIndexType == MathListSubIndexType.Degree
-              ? radical.Degree.AtomAt(index.SubIndex)
-              : radical.Radicand.AtomAt(index.SubIndex)
-            : null;
-        case MathListSubIndexType.Numerator:
-        case MathListSubIndexType.Denominator:
-          return
-            atom is Atoms.Fraction frac
-            ? index.SubIndexType == MathListSubIndexType.Denominator
-              ? frac.Denominator.AtomAt(index.SubIndex)
-              : frac.Numerator.AtomAt(index.SubIndex)
-            : null;
-        case MathListSubIndexType.Inner:
-          return atom is Atoms.Inner inner ? inner.InnerList.AtomAt(index.SubIndex) : null;
-        default:
-          throw new SubIndexTypeMismatchException(index);
-      }
+      return index.SubIndexInfo switch {
+        null => atom,
+        (MathListSubIndexType.BetweenBaseAndScripts, _) => null,
+        (MathListSubIndexType.Subscript, var subIndex) => atom.Subscript.AtomAt(subIndex),
+        (MathListSubIndexType.Superscript, var subIndex) => atom.Superscript.AtomAt(subIndex),
+        (MathListSubIndexType.Degree, var subIndex) => atom is Atoms.Radical radical ? radical.Degree.AtomAt(subIndex) : null,
+        (MathListSubIndexType.Radicand, var subIndex) => atom is Atoms.Radical radical ? radical.Radicand.AtomAt(subIndex) : null,
+        (MathListSubIndexType.Numerator, var subIndex) => atom is Atoms.Fraction frac ? frac.Numerator.AtomAt(subIndex) : null,
+        (MathListSubIndexType.Denominator, var subIndex) => atom is Atoms.Fraction frac ? frac.Denominator.AtomAt(subIndex) : null,
+        (MathListSubIndexType.Inner, var subIndex) => atom is Atoms.Inner inner ? inner.InnerList.AtomAt(subIndex) : null,
+        _ => throw new SubIndexTypeMismatchException(index),
+      };
     }
   }
 }

--- a/CSharpMath/Editor/Extensions/RadicalDisplay.cs
+++ b/CSharpMath/Editor/Extensions/RadicalDisplay.cs
@@ -5,30 +5,30 @@ namespace CSharpMath.Editor {
   using Display.FrontEnd;
 
   partial class Extensions {
-    public static MathListIndex IndexForPoint<TFont, TGlyph>(
+    public static MathListIndex? IndexForPoint<TFont, TGlyph>(
       this RadicalDisplay<TFont, TGlyph> self,
       TypesettingContext<TFont, TGlyph> context,
       PointF point) where TFont : IFont<TGlyph> =>
       // We can be before or after the radical
       point.X < self.Position.X - PixelDelta
-      //We are before the radical, so
-      ? MathListIndex.Level0Index(self.Range.Location)
+      // We are before the radical, so
+      ? new(self.Range.Location)
       : point.X > self.Position.X + self.Width + PixelDelta
-      //We are after the radical
-      ? MathListIndex.Level0Index(self.Range.End)
-      //We can be either near the degree or the radicand
+      // We are after the radical
+      ? new(self.Range.End)
+      // We can be either near the degree or the radicand
       : DistanceFromPointToRect(point, self.Degree != null ? new RectangleF(self.Degree.Position, self.Degree.DisplayBounds().Size) : default)
       < DistanceFromPointToRect(point, new RectangleF(self.Radicand.Position, self.Radicand.DisplayBounds().Size))
-      ? self.Degree != null
-        ? MathListIndex.IndexAtLocation(self.Range.Location, MathListSubIndexType.Degree, self.Degree.IndexForPoint(context, point))
-        : MathListIndex.Level0Index(self.Range.Location)
-      : MathListIndex.IndexAtLocation(self.Range.Location, MathListSubIndexType.Radicand, self.Radicand.IndexForPoint(context, point));
+      ? self.Degree is { }
+        ? self.Degree.IndexForPoint(context, point)?.WrapInIndex(self.Range.Location, MathListSubIndexType.Degree)
+        : new(self.Range.Location)
+      : self.Radicand.IndexForPoint(context, point)?.WrapInIndex(self.Range.Location, MathListSubIndexType.Radicand);
 
     public static PointF? PointForIndex<TFont, TGlyph>(
       this RadicalDisplay<TFont, TGlyph> self,
       TypesettingContext<TFont, TGlyph> _,
       MathListIndex index) where TFont : IFont<TGlyph> {
-      if (index.SubIndexType != MathListSubIndexType.None)
+      if (index.SubIndexInfo is { })
         throw new ArgumentException("The subindex must be none to get the closest point for it.", nameof(index));
 
       if (index.AtomIndex == self.Range.End)
@@ -42,7 +42,7 @@ namespace CSharpMath.Editor {
       this RadicalDisplay<TFont, TGlyph> self,
       MathListIndex index,
       Color color) where TFont : IFont<TGlyph> {
-      if (index.SubIndexType != MathListSubIndexType.None)
+      if (index.SubIndexInfo is { })
         throw new ArgumentException("The subindex must be none to get the highlight a character in it.", nameof(index));
       self.Highlight(color);
     }

--- a/CSharpMath/Editor/Extensions/RadicalDisplay.cs
+++ b/CSharpMath/Editor/Extensions/RadicalDisplay.cs
@@ -20,9 +20,9 @@ namespace CSharpMath.Editor {
       : DistanceFromPointToRect(point, self.Degree != null ? new RectangleF(self.Degree.Position, self.Degree.DisplayBounds().Size) : default)
       < DistanceFromPointToRect(point, new RectangleF(self.Radicand.Position, self.Radicand.DisplayBounds().Size))
       ? self.Degree is { }
-        ? self.Degree.IndexForPoint(context, point)?.WrapInIndex(self.Range.Location, MathListSubIndexType.Degree)
+        ? self.Degree.IndexForPoint(context, point)?.Wrap(self.Range.Location, MathListSubIndexType.Degree)
         : new(self.Range.Location)
-      : self.Radicand.IndexForPoint(context, point)?.WrapInIndex(self.Range.Location, MathListSubIndexType.Radicand);
+      : self.Radicand.IndexForPoint(context, point)?.Wrap(self.Range.Location, MathListSubIndexType.Radicand);
 
     public static PointF? PointForIndex<TFont, TGlyph>(
       this RadicalDisplay<TFont, TGlyph> self,

--- a/CSharpMath/Editor/Extensions/TextLineDisplay.cs
+++ b/CSharpMath/Editor/Extensions/TextLineDisplay.cs
@@ -79,33 +79,26 @@ namespace CSharpMath.Editor {
       where TFont : IFont<TGlyph> {
       // Convert the point to the reference of the CTLine
       var relativePoint = new PointF(point.X - self.Position.X, point.Y - self.Position.Y);
-      var runsAndIndicies =
-        self.Runs
-        .Select(run => (run, run.Run.GlyphIndexForXOffset(context, relativePoint.Plus(run.Position).X)))
-        .Where(x => x.Item2.HasValue)
-        .ToArray();
-      if (runsAndIndicies.Length == 0)
-        return null;
-      var (r, nindex) = runsAndIndicies.Single();
-      var index = nindex.GetValueOrDefault();
-      var diffLng = r.Run.Length != r.Range.Length;
-      if (index < 0 || (!diffLng && index > self.Range.Length) || (diffLng && index > r.Run.Length))
-        throw new Atom.InvalidCodePathException
-          ($"Returned index out of range: {index}, range ({self.Range.Location}, {self.Range.Length})");
-      return diffLng
-        ? index > r.Run.Length / 2
-          ? MathListIndex.Level0Index(self.Range.End)
-          : MathListIndex.Level0Index(self.Range.Location)
-        : MathListIndex.Level0Index(self.Range.Location + index);
+      foreach (var r in self.Runs)
+        if (r.Run.GlyphIndexForXOffset(context, relativePoint.Plus(r.Position).X) is { } index) {
+          var diffLng = r.Run.Length != r.Range.Length;
+          if (index < 0 || !diffLng && index > self.Range.Length || diffLng && index > r.Run.Length)
+            throw new Atom.InvalidCodePathException
+              ($"Returned index out of range: {index}, range ({self.Range.Location}, {self.Range.Length})");
+          return diffLng
+            ? index > r.Run.Length / 2 ? new(self.Range.End) : new(self.Range.Location)
+            : new(self.Range.Location + index);
+        }
+      return null;
     }
 
     public static (TextRunDisplay<TFont, TGlyph> run, int charIndex)
       GetRunAndCharIndexFromStringIndex<TFont, TGlyph>(
       this TextLineDisplay<TFont, TGlyph> self, int lineCharIndex) where TFont : IFont<TGlyph> {
       var currentRun = self.Runs.First(s => (lineCharIndex -= s.Run.Text.Length) < 0);
-      //return offset for target char in its containing string
+      // Return offset for target char in its containing string
       return (currentRun, currentRun.Run.Text.Length + lineCharIndex);
-      /* //Quick test in C# Interactive
+      /* // Quick test in C# Interactive
 int strIndex = 6; //offset for target char if all strings in array are fused together
 var ss = new[] { "abcde", "fgh", "i", "f", "g" };
 var c = ss.First(s => (strIndex -= s.Length) < 0);
@@ -141,7 +134,7 @@ return c.Length + strIndex; //offset for target char in its containing string
       (this TextLineDisplay<TFont, TGlyph> self, TypesettingContext<TFont, TGlyph> context, MathListIndex index)
       where TFont : IFont<TGlyph> {
       float offset;
-      if (!(index.SubIndexType is MathListSubIndexType.None))
+      if (index.SubIndexInfo is { })
         throw new ArgumentException
           ($"An index in a {nameof(TextLineDisplay<TFont, TGlyph>)} cannot have sub-indexes.", nameof(index));
       if (index.AtomIndex == self.Range.End)
@@ -164,10 +157,10 @@ return c.Length + strIndex; //offset for target char in its containing string
       if (!self.Range.Contains(index.AtomIndex))
         throw new ArgumentOutOfRangeException
           (nameof(index), index, $"The index is not in the range {self.Range}.");
-      if (index.SubIndexType is MathListSubIndexType.None)
+      if (index.SubIndexInfo is { })
         throw new ArgumentException
           ("The subindex type must not be none to be able to highlight it.", nameof(index));
-      if (index.SubIndexType is MathListSubIndexType.BetweenBaseAndScripts)
+      if (index.SubIndexInfo is (MathListSubIndexType.BetweenBaseAndScripts, _))
         throw new ArgumentException("Nucleus highlighting is not supported.", nameof(index));
       // index is in unicode code points, while attrString is not
       var (run, charIndex) = self.GetRunAndCharIndexFromCodepointIndex(index.AtomIndex - self.Range.Location);

--- a/CSharpMath/Editor/Extensions/TextLineDisplay.cs
+++ b/CSharpMath/Editor/Extensions/TextLineDisplay.cs
@@ -157,7 +157,7 @@ return c.Length + strIndex; //offset for target char in its containing string
       if (!self.Range.Contains(index.AtomIndex))
         throw new ArgumentOutOfRangeException
           (nameof(index), index, $"The index is not in the range {self.Range}.");
-      if (index.SubIndexInfo is { })
+      if (index.SubIndexInfo is null)
         throw new ArgumentException
           ("The subindex type must not be none to be able to highlight it.", nameof(index));
       if (index.SubIndexInfo is (MathListSubIndexType.BetweenBaseAndScripts, _))

--- a/CSharpMath/Editor/MathKeyboard.cs
+++ b/CSharpMath/Editor/MathKeyboard.cs
@@ -262,7 +262,7 @@ namespace CSharpMath.Editor {
         if (_insertionIndex is null)
           throw new InvalidOperationException($"{nameof(_insertionIndex)} is null.");
         switch (MathList.AtomAt(_insertionIndex)) {
-          case null: //After Count
+          case null: // After Count
             var levelDown = _insertionIndex.LevelDown();
             var levelDownAtom = MathList.AtomAt(levelDown);
             switch (_insertionIndex.FinalSubIndexType) {
@@ -276,13 +276,13 @@ namespace CSharpMath.Editor {
                 if (levelDownAtom is Atoms.Radical)
                   _insertionIndex = levelDown.LevelUpWithSubIndex(MathListSubIndexType.Radicand, 0);
                 else
-                  throw new SubIndexTypeMismatchException(typeof(Atoms.Radical), levelDown);
+                  throw new SubIndexTypeMismatchException(nameof(Atoms.Radical), levelDown.AtomIndex);
                 break;
               case MathListSubIndexType.Numerator:
                 if (levelDownAtom is Atoms.Fraction)
                   _insertionIndex = levelDown.LevelUpWithSubIndex(MathListSubIndexType.Denominator, 0);
                 else
-                  throw new SubIndexTypeMismatchException(typeof(Atoms.Fraction), levelDown);
+                  throw new SubIndexTypeMismatchException(nameof(Atoms.Fraction), levelDown.AtomIndex);
                 break;
               case MathListSubIndexType.Radicand:
               case MathListSubIndexType.Denominator:

--- a/CSharpMath/Editor/MathKeyboard.cs
+++ b/CSharpMath/Editor/MathKeyboard.cs
@@ -59,9 +59,9 @@ namespace CSharpMath.Editor {
       }
     }
     public Display.Displays.ListDisplay<TFont, TGlyph>? Display { get; protected set; }
-    public MathList MathList { get; } = new MathList();
+    public MathList MathList { get; } = [];
     public string LaTeX => LaTeXParser.MathListToLaTeX(MathList).ToString();
-    private MathListIndex _insertionIndex = MathListIndex.Level0Index(0);
+    private MathListIndex _insertionIndex = new(0);
     public MathListIndex InsertionIndex {
       get => _insertionIndex;
       set {
@@ -102,7 +102,7 @@ namespace CSharpMath.Editor {
           // Create an empty atom and move the insertion index up.
           var emptyAtom = LaTeXSettings.Placeholder;
           SetScript(emptyAtom, LaTeXSettings.PlaceholderList);
-          MathList.InsertAndAdvance(ref _insertionIndex, emptyAtom, subIndexType);
+          _insertionIndex = MathList.InsertAndAdvance(_insertionIndex, emptyAtom, subIndexType);
         }
         static bool IsFullPlaceholderRequired(MathAtom mathAtom) =>
           mathAtom switch {
@@ -113,7 +113,7 @@ namespace CSharpMath.Editor {
             Atoms.Punctuation _ => true,
             _ => false
           };
-        if (!(_insertionIndex.Previous is MathListIndex previous)) {
+        if (_insertionIndex.Previous is not MathListIndex previous) {
           CreateEmptyAtom();
         } else {
           var isBetweenBaseAndScripts =
@@ -123,9 +123,7 @@ namespace CSharpMath.Editor {
             ? _insertionIndex.LevelDown()
               ?? throw new InvalidCodePathException("BetweenBaseAndScripts index has null LevelDown")
             : previous;
-          var prevAtom = MathList.AtomAt(prevIndexCorrected);
-          if (prevAtom is null)
-            throw new InvalidCodePathException("prevAtom is null");
+          var prevAtom = MathList.AtomAt(prevIndexCorrected) ?? throw new InvalidCodePathException("prevAtom is null");
           if (!isBetweenBaseAndScripts && IsFullPlaceholderRequired(prevAtom)) {
             CreateEmptyAtom();
           } else {
@@ -133,8 +131,7 @@ namespace CSharpMath.Editor {
             if (script.IsEmpty()) {
               SetScript(prevAtom, LaTeXSettings.PlaceholderList);
             }
-            _insertionIndex = prevIndexCorrected.LevelUpWithSubIndex
-              (subIndexType, MathListIndex.Level0Index(0));
+            _insertionIndex = prevIndexCorrected.LevelUpWithSubIndex(subIndexType, 0);
           }
         }
       }
@@ -167,14 +164,14 @@ namespace CSharpMath.Editor {
           numerator.Push(new Atoms.Number("1"));
         if (MathList.AtomAt(_insertionIndex.Previous) is Atoms.Fraction)
           // Add a times symbol
-          MathList.InsertAndAdvance(ref _insertionIndex, LaTeXSettings.Times, MathListSubIndexType.None);
-        MathList.InsertAndAdvance(ref _insertionIndex, new Atoms.Fraction(
-          new MathList(numerator),
+          _insertionIndex = MathList.InsertAndAdvance(_insertionIndex, LaTeXSettings.Times, null);
+        _insertionIndex = MathList.InsertAndAdvance(_insertionIndex, new Atoms.Fraction(
+          [.. numerator],
           LaTeXSettings.PlaceholderList
         ), MathListSubIndexType.Denominator);
       }
       void InsertInner(string left, string right) =>
-        MathList.InsertAndAdvance(ref _insertionIndex,
+        _insertionIndex = MathList.InsertAndAdvance(_insertionIndex,
           new Atoms.Inner(new Boundary(left), LaTeXSettings.PlaceholderList, new Boundary(right)),
           MathListSubIndexType.Inner);
 
@@ -185,7 +182,7 @@ namespace CSharpMath.Editor {
           case null: // At beginning of line
             var levelDown = _insertionIndex.LevelDown();
             switch (_insertionIndex.FinalSubIndexType) {
-              case MathListSubIndexType.None:
+              case null:
                 goto default;
               case var _ when levelDown is null:
                 throw new InvalidCodePathException("Null levelDown despite non-None FinalSubIndexType");
@@ -194,42 +191,31 @@ namespace CSharpMath.Editor {
                 if (scriptAtom is null)
                   throw new InvalidCodePathException("Invalid levelDown");
                 if (scriptAtom.Subscript.IsNonEmpty())
-                  _insertionIndex = levelDown.LevelUpWithSubIndex
-                    (MathListSubIndexType.Subscript,
-                     MathListIndex.Level0Index(scriptAtom.Subscript.Count));
+                  _insertionIndex = levelDown.LevelUpWithSubIndex(MathListSubIndexType.Subscript, scriptAtom.Subscript.Count);
                 else
                   goto case MathListSubIndexType.Subscript;
                 break;
               case MathListSubIndexType.Subscript:
-                _insertionIndex = levelDown.LevelUpWithSubIndex
-                  (MathListSubIndexType.BetweenBaseAndScripts, MathListIndex.Level0Index(1));
+                _insertionIndex = levelDown.LevelUpWithSubIndex(MathListSubIndexType.BetweenBaseAndScripts, 1);
                 break;
               case MathListSubIndexType.BetweenBaseAndScripts:
                 if (MathList.AtomAt(levelDown) is Atoms.Radical rad && rad.Radicand.IsNonEmpty())
-                  _insertionIndex = levelDown.LevelUpWithSubIndex
-                    (MathListSubIndexType.Radicand,
-                     MathListIndex.Level0Index(rad.Radicand.Count));
+                  _insertionIndex = levelDown.LevelUpWithSubIndex(MathListSubIndexType.Radicand, rad.Radicand.Count);
                 else if (MathList.AtomAt(levelDown) is Atoms.Fraction frac && frac.Denominator.IsNonEmpty())
-                  _insertionIndex = levelDown.LevelUpWithSubIndex
-                    (MathListSubIndexType.Denominator,
-                     MathListIndex.Level0Index(frac.Denominator.Count));
+                  _insertionIndex = levelDown.LevelUpWithSubIndex(MathListSubIndexType.Denominator, frac.Denominator.Count);
                 else if (MathList.AtomAt(levelDown) is Atoms.Inner inner && inner.InnerList.IsNonEmpty())
-                  _insertionIndex = levelDown.LevelUpWithSubIndex
-                    (MathListSubIndexType.Inner,
-                     MathListIndex.Level0Index(inner.InnerList.Count));
+                  _insertionIndex = levelDown.LevelUpWithSubIndex(MathListSubIndexType.Inner, inner.InnerList.Count);
                 else goto case MathListSubIndexType.Radicand;
                 break;
               case MathListSubIndexType.Radicand:
                 if (MathList.AtomAt(levelDown) is Atoms.Radical radDeg && radDeg.Degree.IsNonEmpty())
-                  _insertionIndex = levelDown.LevelUpWithSubIndex
-                    (MathListSubIndexType.Degree, MathListIndex.Level0Index(radDeg.Degree.Count));
+                  _insertionIndex = levelDown.LevelUpWithSubIndex(MathListSubIndexType.Degree, radDeg.Degree.Count);
                 else
                   goto case MathListSubIndexType.Denominator;
                 break;
               case MathListSubIndexType.Denominator:
                 if (MathList.AtomAt(levelDown) is Atoms.Fraction fracNum && fracNum.Numerator.IsNonEmpty())
-                  _insertionIndex = levelDown.LevelUpWithSubIndex
-                    (MathListSubIndexType.Numerator, MathListIndex.Level0Index(fracNum.Numerator.Count));
+                  _insertionIndex = levelDown.LevelUpWithSubIndex(MathListSubIndexType.Numerator, fracNum.Numerator.Count);
                 else
                   goto default;
                 break;
@@ -242,24 +228,19 @@ namespace CSharpMath.Editor {
             }
             break;
           case { Superscript: var s } when s.IsNonEmpty():
-            _insertionIndex = prev.LevelUpWithSubIndex
-              (MathListSubIndexType.Superscript, MathListIndex.Level0Index(s.Count));
+            _insertionIndex = prev.LevelUpWithSubIndex(MathListSubIndexType.Superscript, s.Count);
             break;
           case { Subscript: var s } when s.IsNonEmpty():
-            _insertionIndex = prev.LevelUpWithSubIndex
-              (MathListSubIndexType.Subscript, MathListIndex.Level0Index(s.Count));
+            _insertionIndex = prev.LevelUpWithSubIndex(MathListSubIndexType.Subscript, s.Count);
             break;
           case Atoms.Inner { InnerList: var l }:
-            _insertionIndex = prev.LevelUpWithSubIndex
-              (MathListSubIndexType.Inner, MathListIndex.Level0Index(l.Count));
+            _insertionIndex = prev.LevelUpWithSubIndex(MathListSubIndexType.Inner, l.Count);
             break;
           case Atoms.Radical { Radicand: var r }:
-            _insertionIndex = prev.LevelUpWithSubIndex
-              (MathListSubIndexType.Radicand, MathListIndex.Level0Index(r.Count));
+            _insertionIndex = prev.LevelUpWithSubIndex(MathListSubIndexType.Radicand, r.Count);
             break;
           case Atoms.Fraction { Denominator: var d }:
-            _insertionIndex = prev.LevelUpWithSubIndex
-              (MathListSubIndexType.Denominator, MathListIndex.Level0Index(d.Count));
+            _insertionIndex = prev.LevelUpWithSubIndex(MathListSubIndexType.Denominator, d.Count);
             break;
           default:
             _insertionIndex = prev;
@@ -285,7 +266,7 @@ namespace CSharpMath.Editor {
             var levelDown = _insertionIndex.LevelDown();
             var levelDownAtom = MathList.AtomAt(levelDown);
             switch (_insertionIndex.FinalSubIndexType) {
-              case MathListSubIndexType.None:
+              case null:
                 goto default;
               case var _ when levelDown is null:
                 throw new InvalidCodePathException("Null levelDown despite non-None FinalSubIndexType");
@@ -293,15 +274,13 @@ namespace CSharpMath.Editor {
                 throw new InvalidCodePathException("Invalid levelDown");
               case MathListSubIndexType.Degree:
                 if (levelDownAtom is Atoms.Radical)
-                  _insertionIndex = levelDown.LevelUpWithSubIndex
-                    (MathListSubIndexType.Radicand, MathListIndex.Level0Index(0));
+                  _insertionIndex = levelDown.LevelUpWithSubIndex(MathListSubIndexType.Radicand, 0);
                 else
                   throw new SubIndexTypeMismatchException(typeof(Atoms.Radical), levelDown);
                 break;
               case MathListSubIndexType.Numerator:
                 if (levelDownAtom is Atoms.Fraction)
-                  _insertionIndex = levelDown.LevelUpWithSubIndex
-                    (MathListSubIndexType.Denominator, MathListIndex.Level0Index(0));
+                  _insertionIndex = levelDown.LevelUpWithSubIndex(MathListSubIndexType.Denominator, 0);
                 else
                   throw new SubIndexTypeMismatchException(typeof(Atoms.Fraction), levelDown);
                 break;
@@ -309,22 +288,19 @@ namespace CSharpMath.Editor {
               case MathListSubIndexType.Denominator:
               case MathListSubIndexType.Inner:
                 if (levelDownAtom.Superscript.IsNonEmpty() || levelDownAtom.Subscript.IsNonEmpty())
-                  _insertionIndex = levelDown.LevelUpWithSubIndex
-                    (MathListSubIndexType.BetweenBaseAndScripts, MathListIndex.Level0Index(1));
+                  _insertionIndex = levelDown.LevelUpWithSubIndex(MathListSubIndexType.BetweenBaseAndScripts, 1);
                 else
                   goto default;
                 break;
               case MathListSubIndexType.BetweenBaseAndScripts:
                 if (levelDownAtom.Subscript.IsNonEmpty())
-                  _insertionIndex = levelDown.LevelUpWithSubIndex
-                    (MathListSubIndexType.Subscript, MathListIndex.Level0Index(0));
+                  _insertionIndex = levelDown.LevelUpWithSubIndex(MathListSubIndexType.Subscript, 0);
                 else
                   goto case MathListSubIndexType.Subscript;
                 break;
               case MathListSubIndexType.Subscript:
                 if (levelDownAtom.Superscript.IsNonEmpty())
-                  _insertionIndex = levelDown.LevelUpWithSubIndex
-                    (MathListSubIndexType.Superscript, MathListIndex.Level0Index(0));
+                  _insertionIndex = levelDown.LevelUpWithSubIndex(MathListSubIndexType.Superscript, 0);
                 else
                   goto default;
                 break;
@@ -340,24 +316,20 @@ namespace CSharpMath.Editor {
               throw new InvalidCodePathException
                 ("_insertionIndex.FinalSubIndexType is BetweenBaseAndScripts but levelDown is null");
             _insertionIndex = levelDown.LevelUpWithSubIndex(
-              a.Subscript.IsNonEmpty() ? MathListSubIndexType.Subscript : MathListSubIndexType.Superscript,
-              MathListIndex.Level0Index(0));
+              a.Subscript.IsNonEmpty() ? MathListSubIndexType.Subscript : MathListSubIndexType.Superscript, 0);
             break;
           case Atoms.Inner _:
-            _insertionIndex = _insertionIndex.LevelUpWithSubIndex(MathListSubIndexType.Inner, MathListIndex.Level0Index(0));
+            _insertionIndex = _insertionIndex.LevelUpWithSubIndex(MathListSubIndexType.Inner, 0);
             break;
           case Atoms.Fraction _:
-            _insertionIndex = _insertionIndex.LevelUpWithSubIndex
-              (MathListSubIndexType.Numerator, MathListIndex.Level0Index(0));
+            _insertionIndex = _insertionIndex.LevelUpWithSubIndex(MathListSubIndexType.Numerator, 0);
             break;
           case Atoms.Radical rad:
             _insertionIndex = _insertionIndex.LevelUpWithSubIndex(
-              rad.Degree.IsNonEmpty() ? MathListSubIndexType.Degree : MathListSubIndexType.Radicand,
-              MathListIndex.Level0Index(0));
+              rad.Degree.IsNonEmpty() ? MathListSubIndexType.Degree : MathListSubIndexType.Radicand, 0);
             break;
           case var a when a.Superscript.IsNonEmpty() || a.Subscript.IsNonEmpty():
-            _insertionIndex = _insertionIndex.LevelUpWithSubIndex
-              (MathListSubIndexType.BetweenBaseAndScripts, MathListIndex.Level0Index(1));
+            _insertionIndex = _insertionIndex.LevelUpWithSubIndex(MathListSubIndexType.BetweenBaseAndScripts, 1);
             break;
           case Atoms.Placeholder _ when MathList.AtomAt(_insertionIndex.Next) is null:
             // Skip right side of placeholders when end of line
@@ -375,20 +347,18 @@ namespace CSharpMath.Editor {
 
       void DeleteBackwards() {
         // delete the last atom from the list
-        if (HasText && _insertionIndex.Previous is MathListIndex previous) {
-          _insertionIndex = previous;
-          MathList.RemoveAt(ref _insertionIndex);
-        }
+        if (HasText && _insertionIndex.Previous is MathListIndex previous)
+          _insertionIndex = MathList.RemoveAt(previous);
       }
 
       static bool IsPlaceholderList(MathList ml) => ml.Count == 1 && ml[0] is Atoms.Placeholder;
       void InsertAtom(MathAtom a) =>
-        MathList.InsertAndAdvance(ref _insertionIndex, a,
+        _insertionIndex = MathList.InsertAndAdvance(_insertionIndex, a,
           a switch {
             Atoms.Fraction _ => MathListSubIndexType.Numerator,
             Atoms.Radical { Degree: { } d } when IsPlaceholderList(d) => MathListSubIndexType.Degree,
             Atoms.Radical _ => MathListSubIndexType.Radicand,
-            _ => MathListSubIndexType.None
+            _ => null
           });
       void InsertSymbolName(string name, bool subscript = false, bool superscript = false) {
         var atom =
@@ -431,7 +401,7 @@ namespace CSharpMath.Editor {
           break;
         case MathKeyboardInput.Clear:
           MathList.Clear();
-          InsertionIndex = MathListIndex.Level0Index(0);
+          InsertionIndex = new(0);
           break;
         case MathKeyboardInput.Return:
           ReturnPressed?.Invoke(this, EventArgs.Empty);
@@ -826,22 +796,21 @@ namespace CSharpMath.Editor {
 
     public void MoveCaretToPoint(PointF point) {
       point.Y *= -1; //inverted canvas, blah blah
-      InsertionIndex = ClosestIndexToPoint(point) ?? MathListIndex.Level0Index(MathList.Atoms.Count);
+      InsertionIndex = ClosestIndexToPoint(point) ?? new(MathList.Atoms.Count);
     }
 
     public void Clear() {
       MathList.Clear();
-      InsertionIndex = MathListIndex.Level0Index(0);
+      InsertionIndex = new(0);
     }
 
     // Insert a list at a given point.
     public void InsertMathList(MathList list, PointF point) {
-      var detailedIndex = ClosestIndexToPoint(point) ?? MathListIndex.Level0Index(0);
+      var detailedIndex = ClosestIndexToPoint(point) ?? new(0);
       // insert at the given index - but don't consider sublevels at this point
-      var index = MathListIndex.Level0Index(detailedIndex.AtomIndex);
-      foreach (var atom in list.Atoms) {
-        MathList.InsertAndAdvance(ref index, atom, MathListSubIndexType.None);
-      }
+      var index = new MathListIndex(detailedIndex.AtomIndex);
+      foreach (var atom in list.Atoms)
+        index = MathList.InsertAndAdvance(index, atom, null);
       InsertionIndex = index; // move the index to the end of the new list.
     }
 

--- a/CSharpMath/Editor/MathListIndex.cs
+++ b/CSharpMath/Editor/MathListIndex.cs
@@ -34,29 +34,21 @@ namespace CSharpMath.Editor {
 * 
 * The level of an index is the number of nodes in the LinkedList to get to the final path.
 * </summary>*/
-  public class MathListIndex(int atomIndex, (MathListSubIndexType SubIndexType, MathListIndex SubIndex)? subIndexInfo = null) {
-
-    ///<summary>The index of the associated atom.</summary>
-    public int AtomIndex { get; } = atomIndex;
-
-    public (MathListSubIndexType SubIndexType, MathListIndex SubIndex)? SubIndexInfo { get; } = subIndexInfo;
-
+  public record class MathListIndex(int AtomIndex, (MathListSubIndexType SubIndexType, MathListIndex SubIndex)? SubIndexInfo = null) {
     /// <summary>
     /// Creates a new MathListIndex that represents a subindex within this list, wrapped at the specified outer atom
     /// index and subindex type.
     /// </summary>
     /// <param name="outerAtomIndex">The zero-based index of the outer atom in the list at which to wrap the subindex.</param>
     /// <param name="type">The type of subindex to create, specifying the relationship to the outer atom.</param>
-    /// <returns>A MathListIndex representing the specified subindex within this list.</returns>
-    public MathListIndex WrapInIndex(int outerAtomIndex, MathListSubIndexType type) => new(outerAtomIndex, (type, this));
+    /// <returns>A <see cref="MathListIndex"> representing the specified subindex within this list.</returns>
+    public MathListIndex Wrap(int outerAtomIndex, MathListSubIndexType type) => new(outerAtomIndex, (type, this));
 
     ///<summary>Creates a new index by replacing the leaf with IndexInfo (type, new(innerAtomIndex)).</summary>
     public MathListIndex LevelUpWithSubIndex(MathListSubIndexType type, int innerAtomIndex) =>
       SubIndexInfo switch {
-        null => new MathListIndex(AtomIndex, (type, new(innerAtomIndex))),
-        (MathListSubIndexType thisType, MathListIndex thisSubIndex) =>
-          new MathListIndex(AtomIndex,
-            (thisType, thisSubIndex.LevelUpWithSubIndex(type, innerAtomIndex)))
+        null => new(AtomIndex, (type, new(innerAtomIndex))),
+        var (thisType, thisSubIndex) => new(AtomIndex, (thisType, thisSubIndex.LevelUpWithSubIndex(type, innerAtomIndex)))
       };
     ///<summary>Creates a new index by removing the last index item. If this is the last one, then returns <see langword="null"/>.</summary>
     public MathListIndex? LevelDown() =>
@@ -118,21 +110,5 @@ namespace CSharpMath.Editor {
         null => $@"[{AtomIndex}]",
         var (type, subIndex) => $@"[{AtomIndex}, {type}:{subIndex.ToString().Trim('[', ']')}]"
       };
-
-    public bool EqualsToIndex(MathListIndex other) =>
-      (SubIndexInfo, other.SubIndexInfo) switch {
-        (null, null) => true,
-        ((_, _), null) => false,
-        (null, (_, _)) => false,
-        ((MathListSubIndexType aType, MathListIndex aIndex), (MathListSubIndexType bType, MathListIndex bIndex)) =>
-          aType == bType && aIndex.EqualsToIndex(bIndex)
-      };
-
-    public override bool Equals(object obj) => obj is MathListIndex index && EqualsToIndex(index);
-    public override int GetHashCode() => unchecked(
-      SubIndexInfo switch {
-        null => AtomIndex * 31 - 1,
-        var (type, subIndex) => AtomIndex * 31 + (int)type * 31 + subIndex.GetHashCode()
-      });
   }
 }

--- a/CSharpMath/Editor/MathListIndex.cs
+++ b/CSharpMath/Editor/MathListIndex.cs
@@ -1,8 +1,6 @@
 namespace CSharpMath.Editor {
   ///<summary>The type of the subindex denotes what branch the path to the atom that this index points to takes.</summary>
   public enum MathListSubIndexType : byte {
-    ///<summary>The index denotes the whole atom, subIndex is null</summary>
-    None = 0,
     ///<summary>The position in the subindex is an index into the nucleus, must be 1</summary>
     BetweenBaseAndScripts,
     ///<summary>The subindex indexes into the superscript</summary>
@@ -36,95 +34,105 @@ namespace CSharpMath.Editor {
 * 
 * The level of an index is the number of nodes in the LinkedList to get to the final path.
 * </summary>*/
-  public class MathListIndex {
-    private MathListIndex() { }
+  public class MathListIndex(int atomIndex, (MathListSubIndexType SubIndexType, MathListIndex SubIndex)? subIndexInfo = null) {
 
     ///<summary>The index of the associated atom.</summary>
-    public int AtomIndex { get; set; }
-    ///<summary>The type of subindex, e.g. superscript, numerator etc.</summary>
-    public MathListSubIndexType SubIndexType { get; set; }
-    ///<summary>The index into the sublist.</summary>
-    public MathListIndex? SubIndex;
+    public int AtomIndex { get; } = atomIndex;
 
-    /** <summary>Factory function to create a `MathListIndex` with no subindexes.</summary>
-        <param name="index">The index of the atom that the `MathListIndex` points at.</param>
-     */
-    public static MathListIndex Level0Index(int index) => new MathListIndex { AtomIndex = index };
-    /** <summary>Factory function to create at `MathListIndex` with a given subIndex.</summary>
-        <param name="location">The location at which the subIndex should is present.</param>
-        <param name="subIndex">The subIndex to be added. Can be nil.</param> 
-        <param name="type">The type of the subIndex.</param> 
-     */
-    public static MathListIndex IndexAtLocation(int location, MathListSubIndexType type, MathListIndex? subIndex) =>
-      new MathListIndex { AtomIndex = location, SubIndexType = type, SubIndex = subIndex };
+    public (MathListSubIndexType SubIndexType, MathListIndex SubIndex)? SubIndexInfo { get; } = subIndexInfo;
 
-    ///<summary>Creates a new index by attaching this index at the end of the current one.</summary>
-    public MathListIndex LevelUpWithSubIndex(MathListSubIndexType type, MathListIndex? subIndex) =>
-      SubIndexType is MathListSubIndexType.None ? IndexAtLocation(AtomIndex, type, subIndex) :
-      IndexAtLocation(AtomIndex, SubIndexType, SubIndex?.LevelUpWithSubIndex(type, subIndex));
-    ///<summary>Creates a new index by removing the last index item. If this is the last one, then returns nil.</summary>
+    /// <summary>
+    /// Creates a new MathListIndex that represents a subindex within this list, wrapped at the specified outer atom
+    /// index and subindex type.
+    /// </summary>
+    /// <param name="outerAtomIndex">The zero-based index of the outer atom in the list at which to wrap the subindex.</param>
+    /// <param name="type">The type of subindex to create, specifying the relationship to the outer atom.</param>
+    /// <returns>A MathListIndex representing the specified subindex within this list.</returns>
+    public MathListIndex WrapInIndex(int outerAtomIndex, MathListSubIndexType type) => new(outerAtomIndex, (type, this));
+
+    ///<summary>Creates a new index by replacing the leaf with IndexInfo (type, new(innerAtomIndex)).</summary>
+    public MathListIndex LevelUpWithSubIndex(MathListSubIndexType type, int innerAtomIndex) =>
+      SubIndexInfo switch {
+        null => new MathListIndex(AtomIndex, (type, new(innerAtomIndex))),
+        (MathListSubIndexType thisType, MathListIndex thisSubIndex) =>
+          new MathListIndex(AtomIndex,
+            (thisType, thisSubIndex.LevelUpWithSubIndex(type, innerAtomIndex)))
+      };
+    ///<summary>Creates a new index by removing the last index item. If this is the last one, then returns <see langword="null"/>.</summary>
     public MathListIndex? LevelDown() =>
-      SubIndexType is MathListSubIndexType.None ? null :
-      SubIndex?.LevelDown() is MathListIndex subIndex ? IndexAtLocation(AtomIndex, SubIndexType, subIndex) :
-      Level0Index(AtomIndex);
+      SubIndexInfo switch {
+        null => null,
+        var (type, subIndex) => subIndex.LevelDown() is { } levelledDownSubIndex ? new(AtomIndex, (type, levelledDownSubIndex)) : new(AtomIndex)
+      };
 
     /** <summary>
      * Returns the previous index if this index is not at the beginning of a line.
      * Note there may be multiple lines in a MathList,
      * e.g. a superscript or a fraction numerator.
-     * This returns <see cref="null"/> if there is no previous index, i.e.
+     * This returns <see langword="null"/> if there is no previous index, i.e.
      * the innermost subindex points to the beginning of a line.</summary>
      */
-    public MathListIndex? Previous => SubIndexType switch {
-      MathListSubIndexType.None => AtomIndex > 0 ? Level0Index(AtomIndex - 1) : null,
-      _ => SubIndex?.Previous is MathListIndex prevSubIndex ? IndexAtLocation(AtomIndex, SubIndexType, prevSubIndex) : null,
+    public MathListIndex? Previous => SubIndexInfo switch {
+      null => AtomIndex > 0 ? new(AtomIndex - 1) : null,
+      var (type, subIndex) => subIndex.Previous is { } prevSubIndex ? new(AtomIndex, (type, prevSubIndex)) : null,
     };
 
-    ///<summary>Returns the next index.</summary>
-    public MathListIndex Next => SubIndexType switch {
-      MathListSubIndexType.None => Level0Index(AtomIndex + 1),
-      MathListSubIndexType.BetweenBaseAndScripts => IndexAtLocation(AtomIndex + 1, SubIndexType, SubIndex),
-      _ => IndexAtLocation(AtomIndex, SubIndexType, SubIndex?.Next),
+    /// <summary>Returns the next index. With the exception of BetweenBaseAndScripts, this adds 1 to the AtomIndex of the leaf.</summary>
+    public MathListIndex Next => SubIndexInfo switch {
+      null => new(AtomIndex + 1),
+      (MathListSubIndexType.BetweenBaseAndScripts, _) => new(AtomIndex + 1, SubIndexInfo),
+      var (type, subIndex) => new(AtomIndex, (type, subIndex.Next))
     };
 
-    ///<summary>Returns true if any of the subIndexes of this index have the given type.</summary>
+    /// <summary>Returns true if any of the subIndexes of this index have the given type.</summary>
     public bool HasSubIndexOfType(MathListSubIndexType subIndexType) =>
-      SubIndexType == subIndexType ? true :
-      SubIndex != null ? SubIndex.HasSubIndexOfType(subIndexType) : false;
-
+      SubIndexInfo switch {
+        null => false,
+        var (type, subIndex) => subIndexType == type || subIndex.HasSubIndexOfType(subIndexType)
+      };
+    /// <summary>Same, or differing only with respect to the final AtomIdex.</summary>
     public bool AtSameLevel(MathListIndex other) =>
-      SubIndexType != other.SubIndexType ? false :
-      // No subindexes, they are at the same level.
-      SubIndexType == MathListSubIndexType.None ? true :
-      // the subindexes are used in different atoms
-      AtomIndex != other.AtomIndex ? false :
-      SubIndex != null && other.SubIndex != null ? SubIndex.AtSameLevel(other.SubIndex) :
-      // No subindexes, they are at the same level.
-      true;
+      (SubIndexInfo, other.SubIndexInfo) switch {
+        (null, null) => true,
+        ((_, _), null) => false,
+        (null, (_, _)) => false,
+        (var (aType, aIndex), var (bType, bIndex)) =>
+          aType == bType && AtomIndex == other.AtomIndex && aIndex.AtSameLevel(bIndex)
+      };
 
     public int FinalIndex =>
-      SubIndexType is MathListSubIndexType.None || SubIndex is null ? AtomIndex : SubIndex.FinalIndex;
+      SubIndexInfo switch {
+        null => AtomIndex,
+        var (_, subIndex) => subIndex.FinalIndex
+      };
 
     ///<summary>Returns the type of the innermost sub index.</summary>
-    public MathListSubIndexType FinalSubIndexType =>
-      SubIndex?.SubIndex is null ? SubIndexType : SubIndex.FinalSubIndexType;
-
-    public MathListIndex FinalSubIndexParent =>
-      SubIndex?.SubIndex is null ? this : SubIndex.FinalSubIndexParent;
+    public MathListSubIndexType? FinalSubIndexType =>
+      SubIndexInfo switch {
+        null => null,
+        var (type, subIndex) => subIndex.SubIndexInfo is null ? type : subIndex.FinalSubIndexType
+      };
 
     public override string ToString() =>
-      SubIndex is null ?
-      $@"[{AtomIndex}]" :
-      $@"[{AtomIndex}, {SubIndexType}:{SubIndex.ToString().Trim('[', ']')}]";
+      SubIndexInfo switch {
+        null => $@"[{AtomIndex}]",
+        var (type, subIndex) => $@"[{AtomIndex}, {type}:{subIndex.ToString().Trim('[', ']')}]"
+      };
 
-    public bool EqualsToIndex(MathListIndex index) =>
-      index is null || AtomIndex != index.AtomIndex || SubIndexType != index.SubIndexType ? false :
-      SubIndex != null && index.SubIndex != null ? SubIndex.EqualsToIndex(index.SubIndex) :
-      index.SubIndex == null;
+    public bool EqualsToIndex(MathListIndex other) =>
+      (SubIndexInfo, other.SubIndexInfo) switch {
+        (null, null) => true,
+        ((_, _), null) => false,
+        (null, (_, _)) => false,
+        ((MathListSubIndexType aType, MathListIndex aIndex), (MathListSubIndexType bType, MathListIndex bIndex)) =>
+          aType == bType && aIndex.EqualsToIndex(bIndex)
+      };
 
-    public override bool Equals(object obj) =>
-      obj is MathListIndex index && EqualsToIndex(index);
-    public override int GetHashCode() =>
-      unchecked((AtomIndex * 31 + (int)SubIndexType) * 31 + (SubIndex?.GetHashCode() ?? -1));
+    public override bool Equals(object obj) => obj is MathListIndex index && EqualsToIndex(index);
+    public override int GetHashCode() => unchecked(
+      SubIndexInfo switch {
+        null => AtomIndex * 31 - 1,
+        var (type, subIndex) => AtomIndex * 31 + (int)type * 31 + subIndex.GetHashCode()
+      });
   }
 }

--- a/CSharpMath/Editor/MathListIndex.cs
+++ b/CSharpMath/Editor/MathListIndex.cs
@@ -41,7 +41,7 @@ namespace CSharpMath.Editor {
     /// </summary>
     /// <param name="outerAtomIndex">The zero-based index of the outer atom in the list at which to wrap the subindex.</param>
     /// <param name="type">The type of subindex to create, specifying the relationship to the outer atom.</param>
-    /// <returns>A <see cref="MathListIndex"> representing the specified subindex within this list.</returns>
+    /// <returns>A <see cref="MathListIndex"/> representing the specified subindex within this list.</returns>
     public MathListIndex Wrap(int outerAtomIndex, MathListSubIndexType type) => new(outerAtomIndex, (type, this));
 
     ///<summary>Creates a new index by replacing the leaf with IndexInfo (type, new(innerAtomIndex)).</summary>

--- a/CSharpMath/Editor/MathListIndex.cs
+++ b/CSharpMath/Editor/MathListIndex.cs
@@ -82,7 +82,7 @@ namespace CSharpMath.Editor {
         null => false,
         var (type, subIndex) => subIndexType == type || subIndex.HasSubIndexOfType(subIndexType)
       };
-    /// <summary>Same, or differing only with respect to the final AtomIdex.</summary>
+    /// <summary>Same, or differing only with respect to the final AtomIndex.</summary>
     public bool AtSameLevel(MathListIndex other) =>
       (SubIndexInfo, other.SubIndexInfo) switch {
         (null, null) => true,

--- a/CSharpMath/Editor/MathListRange.cs
+++ b/CSharpMath/Editor/MathListRange.cs
@@ -5,21 +5,14 @@ using System.Linq;
 namespace CSharpMath.Editor {
   using Atom;
   public readonly struct MathListRange {
-    public MathListRange(int start) =>
-      (Start, Length) = (MathListIndex.Level0Index(start), 1);
-    public MathListRange(MathListIndex start) =>
-      (Start, Length) = (start, 1);
-    public MathListRange(MathListIndex start, int length) =>
-      (Start, Length) = (start, length);
-    public MathListRange(Range range) =>
-      (Start, Length) = (MathListIndex.Level0Index(range.Location), range.Length);
+    public MathListRange(int start) => (Start, Length) = (new(start), 1);
+    public MathListRange(MathListIndex start) => (Start, Length) = (start, 1);
+    public MathListRange(MathListIndex start, int length) => (Start, Length) = (start, length);
+    public MathListRange(Range range) => (Start, Length) = (new(range.Location), range.Length);
     public MathListIndex Start { get; }
     public int Length { get; }
-    public MathListRange? SubIndexRange =>
-      Start.SubIndex != null
-      ? new MathListRange(Start.SubIndex, Length)
-      : new MathListRange?();
-    public Range FinalRange => new Range(Start.FinalIndex, Length);
+    public MathListRange? SubIndexRange => Start.SubIndexInfo is var (_, subIndex) ? new(subIndex, Length) : null;
+    public Range FinalRange => new(Start.FinalIndex, Length);
     public override string ToString() => $"({Start}, {Length})";
     public static MathListRange operator +(MathListRange left, MathListRange right) {
       if (!left.Start.AtSameLevel(right.Start))

--- a/CSharpMath/Editor/MathListRange.cs
+++ b/CSharpMath/Editor/MathListRange.cs
@@ -5,7 +5,7 @@ using System.Linq;
 namespace CSharpMath.Editor {
   using Atom;
   public readonly record struct MathListRange(MathListIndex Start, int Length) {
-    public MathListRange? SubIndexRange => Start.SubIndexInfo is var (_, subIndex) ? new(subIndex, Length) : null;
+    public MathListRange? SubIndexRange => Start.SubIndexInfo is (_, var subIndex) ? new(subIndex, Length) : null;
     public Range FinalRange => new(Start.FinalIndex, Length);
     public override string ToString() => $"({Start}, {Length})";
     public static MathListRange operator +(MathListRange left, MathListRange right) {

--- a/CSharpMath/Editor/MathListRange.cs
+++ b/CSharpMath/Editor/MathListRange.cs
@@ -4,13 +4,7 @@ using System.Linq;
 
 namespace CSharpMath.Editor {
   using Atom;
-  public readonly struct MathListRange {
-    public MathListRange(int start) => (Start, Length) = (new(start), 1);
-    public MathListRange(MathListIndex start) => (Start, Length) = (start, 1);
-    public MathListRange(MathListIndex start, int length) => (Start, Length) = (start, length);
-    public MathListRange(Range range) => (Start, Length) = (new(range.Location), range.Length);
-    public MathListIndex Start { get; }
-    public int Length { get; }
+  public readonly record struct MathListRange(MathListIndex Start, int Length) {
     public MathListRange? SubIndexRange => Start.SubIndexInfo is var (_, subIndex) ? new(subIndex, Length) : null;
     public Range FinalRange => new(Start.FinalIndex, Length);
     public override string ToString() => $"({Start}, {Length})";
@@ -20,11 +14,8 @@ namespace CSharpMath.Editor {
       var leftRange = left.FinalRange;
       var rightRange = right.FinalRange;
       var unionRange = leftRange + rightRange;
-      return new MathListRange(
-        unionRange.Location == leftRange.Location ? left.Start : right.Start,
-        unionRange.Length);
+      return new MathListRange(unionRange.Location == leftRange.Location ? left.Start : right.Start, unionRange.Length);
     }
-    public static MathListRange Combine(IEnumerable<MathListRange> ranges) =>
-      ranges.Aggregate((acc, curr) => acc + curr);
+    public static MathListRange Combine(IEnumerable<MathListRange> ranges) => ranges.Aggregate((acc, curr) => acc + curr);
   }
 }

--- a/CSharpMath/Editor/SubIndexTypeMismatchException.cs
+++ b/CSharpMath/Editor/SubIndexTypeMismatchException.cs
@@ -4,9 +4,6 @@ using System.Text;
 
 namespace CSharpMath.Editor {
   public class SubIndexTypeMismatchException : InvalidOperationException {
-    public SubIndexTypeMismatchException(Type atomType, MathListIndex index) : base(
-      $"{atomType} not found at index {index.AtomIndex}.") { }
-    public SubIndexTypeMismatchException(MathListIndex index) : base(
-      $"{index.SubIndexType} not found at index {index.AtomIndex}.") { }
+    public SubIndexTypeMismatchException(string target, int atomIndex) : base($"{target} not found at index {atomIndex}.") { }
   }
 }

--- a/CSharpMath/PublicAPI.Unshipped.txt
+++ b/CSharpMath/PublicAPI.Unshipped.txt
@@ -985,6 +985,7 @@ CSharpMath.Editor.MathListIndex.SubIndexInfo.init -> void
 CSharpMath.Editor.MathListIndex.Wrap(int outerAtomIndex, CSharpMath.Editor.MathListSubIndexType type) -> CSharpMath.Editor.MathListIndex!
 CSharpMath.Editor.MathListRange
 CSharpMath.Editor.MathListRange.Deconstruct(out CSharpMath.Editor.MathListIndex! Start, out int Length) -> void
+CSharpMath.Editor.MathListRange.Equals(CSharpMath.Editor.MathListRange other) -> bool
 CSharpMath.Editor.MathListRange.FinalRange.get -> CSharpMath.Atom.Range
 CSharpMath.Editor.MathListRange.Length.get -> int
 CSharpMath.Editor.MathListRange.Length.init -> void
@@ -1091,7 +1092,9 @@ override CSharpMath.Display.Displays.TextLineDisplay<TFont, TGlyph>.ToString() -
 override CSharpMath.Display.Displays.TextRunDisplay<TFont, TGlyph>.ToString() -> string!
 override CSharpMath.Display.GlyphPart<TGlyph>.ToString() -> string!
 override CSharpMath.Editor.MathListIndex.Equals(object? obj) -> bool
+override CSharpMath.Editor.MathListIndex.GetHashCode() -> int
 override CSharpMath.Editor.MathListIndex.ToString() -> string!
+override CSharpMath.Editor.MathListRange.GetHashCode() -> int
 override CSharpMath.Editor.MathListRange.ToString() -> string!
 static CSharpMath.Atom.Boundary.operator !=(CSharpMath.Atom.Boundary left, CSharpMath.Atom.Boundary right) -> bool
 static CSharpMath.Atom.Boundary.operator ==(CSharpMath.Atom.Boundary left, CSharpMath.Atom.Boundary right) -> bool
@@ -1218,7 +1221,9 @@ static CSharpMath.Editor.Extensions.XOffsetForGlyphIndex<TFont, TGlyph>(this CSh
 static CSharpMath.Editor.MathListIndex.operator !=(CSharpMath.Editor.MathListIndex? left, CSharpMath.Editor.MathListIndex? right) -> bool
 static CSharpMath.Editor.MathListIndex.operator ==(CSharpMath.Editor.MathListIndex? left, CSharpMath.Editor.MathListIndex? right) -> bool
 static CSharpMath.Editor.MathListRange.Combine(System.Collections.Generic.IEnumerable<CSharpMath.Editor.MathListRange>! ranges) -> CSharpMath.Editor.MathListRange
+static CSharpMath.Editor.MathListRange.operator !=(CSharpMath.Editor.MathListRange left, CSharpMath.Editor.MathListRange right) -> bool
 static CSharpMath.Editor.MathListRange.operator +(CSharpMath.Editor.MathListRange left, CSharpMath.Editor.MathListRange right) -> CSharpMath.Editor.MathListRange
+static CSharpMath.Editor.MathListRange.operator ==(CSharpMath.Editor.MathListRange left, CSharpMath.Editor.MathListRange right) -> bool
 static CSharpMath.Extensions.Append(this System.Text.StringBuilder! sb, System.ReadOnlySpan<char> value) -> System.Text.StringBuilder!
 static CSharpMath.Extensions.CollectionAscent<TFont, TGlyph>(this System.Collections.Generic.IEnumerable<CSharpMath.Display.IDisplay<TFont, TGlyph>!>! displays) -> float
 static CSharpMath.Extensions.CollectionDescent<TFont, TGlyph>(this System.Collections.Generic.IEnumerable<CSharpMath.Display.IDisplay<TFont, TGlyph>!>! displays) -> float
@@ -1275,3 +1280,4 @@ virtual CSharpMath.Editor.MathListIndex.<Clone>$() -> CSharpMath.Editor.MathList
 virtual CSharpMath.Editor.MathListIndex.EqualityContract.get -> System.Type!
 virtual CSharpMath.Editor.MathListIndex.Equals(CSharpMath.Editor.MathListIndex? other) -> bool
 virtual CSharpMath.Editor.MathListIndex.PrintMembers(System.Text.StringBuilder! builder) -> bool
+~override CSharpMath.Editor.MathListRange.Equals(object obj) -> bool

--- a/CSharpMath/PublicAPI.Unshipped.txt
+++ b/CSharpMath/PublicAPI.Unshipped.txt
@@ -968,43 +968,42 @@ CSharpMath.Editor.MathKeyboardInput.Z = 90 -> CSharpMath.Editor.MathKeyboardInpu
 CSharpMath.Editor.MathKeyboardInput.Zeta = 918 -> CSharpMath.Editor.MathKeyboardInput
 CSharpMath.Editor.MathListIndex
 CSharpMath.Editor.MathListIndex.AtomIndex.get -> int
-CSharpMath.Editor.MathListIndex.AtomIndex.set -> void
+CSharpMath.Editor.MathListIndex.AtomIndex.init -> void
 CSharpMath.Editor.MathListIndex.AtSameLevel(CSharpMath.Editor.MathListIndex! other) -> bool
-CSharpMath.Editor.MathListIndex.EqualsToIndex(CSharpMath.Editor.MathListIndex! index) -> bool
+CSharpMath.Editor.MathListIndex.Deconstruct(out int AtomIndex, out (CSharpMath.Editor.MathListSubIndexType SubIndexType, CSharpMath.Editor.MathListIndex! SubIndex)? SubIndexInfo) -> void
 CSharpMath.Editor.MathListIndex.FinalIndex.get -> int
-CSharpMath.Editor.MathListIndex.FinalSubIndexParent.get -> CSharpMath.Editor.MathListIndex!
-CSharpMath.Editor.MathListIndex.FinalSubIndexType.get -> CSharpMath.Editor.MathListSubIndexType
+CSharpMath.Editor.MathListIndex.FinalSubIndexType.get -> CSharpMath.Editor.MathListSubIndexType?
 CSharpMath.Editor.MathListIndex.HasSubIndexOfType(CSharpMath.Editor.MathListSubIndexType subIndexType) -> bool
 CSharpMath.Editor.MathListIndex.LevelDown() -> CSharpMath.Editor.MathListIndex?
-CSharpMath.Editor.MathListIndex.LevelUpWithSubIndex(CSharpMath.Editor.MathListSubIndexType type, CSharpMath.Editor.MathListIndex? subIndex) -> CSharpMath.Editor.MathListIndex!
+CSharpMath.Editor.MathListIndex.LevelUpWithSubIndex(CSharpMath.Editor.MathListSubIndexType type, int innerAtomIndex) -> CSharpMath.Editor.MathListIndex!
+CSharpMath.Editor.MathListIndex.MathListIndex(CSharpMath.Editor.MathListIndex! original) -> void
+CSharpMath.Editor.MathListIndex.MathListIndex(int AtomIndex, (CSharpMath.Editor.MathListSubIndexType SubIndexType, CSharpMath.Editor.MathListIndex! SubIndex)? SubIndexInfo = null) -> void
 CSharpMath.Editor.MathListIndex.Next.get -> CSharpMath.Editor.MathListIndex!
 CSharpMath.Editor.MathListIndex.Previous.get -> CSharpMath.Editor.MathListIndex?
-CSharpMath.Editor.MathListIndex.SubIndex -> CSharpMath.Editor.MathListIndex?
-CSharpMath.Editor.MathListIndex.SubIndexType.get -> CSharpMath.Editor.MathListSubIndexType
-CSharpMath.Editor.MathListIndex.SubIndexType.set -> void
+CSharpMath.Editor.MathListIndex.SubIndexInfo.get -> (CSharpMath.Editor.MathListSubIndexType SubIndexType, CSharpMath.Editor.MathListIndex! SubIndex)?
+CSharpMath.Editor.MathListIndex.SubIndexInfo.init -> void
+CSharpMath.Editor.MathListIndex.Wrap(int outerAtomIndex, CSharpMath.Editor.MathListSubIndexType type) -> CSharpMath.Editor.MathListIndex!
 CSharpMath.Editor.MathListRange
+CSharpMath.Editor.MathListRange.Deconstruct(out CSharpMath.Editor.MathListIndex! Start, out int Length) -> void
 CSharpMath.Editor.MathListRange.FinalRange.get -> CSharpMath.Atom.Range
 CSharpMath.Editor.MathListRange.Length.get -> int
+CSharpMath.Editor.MathListRange.Length.init -> void
 CSharpMath.Editor.MathListRange.MathListRange() -> void
-CSharpMath.Editor.MathListRange.MathListRange(CSharpMath.Atom.Range range) -> void
-CSharpMath.Editor.MathListRange.MathListRange(CSharpMath.Editor.MathListIndex! start) -> void
-CSharpMath.Editor.MathListRange.MathListRange(CSharpMath.Editor.MathListIndex! start, int length) -> void
-CSharpMath.Editor.MathListRange.MathListRange(int start) -> void
+CSharpMath.Editor.MathListRange.MathListRange(CSharpMath.Editor.MathListIndex! Start, int Length) -> void
 CSharpMath.Editor.MathListRange.Start.get -> CSharpMath.Editor.MathListIndex!
+CSharpMath.Editor.MathListRange.Start.init -> void
 CSharpMath.Editor.MathListRange.SubIndexRange.get -> CSharpMath.Editor.MathListRange?
 CSharpMath.Editor.MathListSubIndexType
-CSharpMath.Editor.MathListSubIndexType.BetweenBaseAndScripts = 1 -> CSharpMath.Editor.MathListSubIndexType
-CSharpMath.Editor.MathListSubIndexType.Degree = 7 -> CSharpMath.Editor.MathListSubIndexType
-CSharpMath.Editor.MathListSubIndexType.Denominator = 5 -> CSharpMath.Editor.MathListSubIndexType
-CSharpMath.Editor.MathListSubIndexType.Inner = 8 -> CSharpMath.Editor.MathListSubIndexType
-CSharpMath.Editor.MathListSubIndexType.None = 0 -> CSharpMath.Editor.MathListSubIndexType
-CSharpMath.Editor.MathListSubIndexType.Numerator = 4 -> CSharpMath.Editor.MathListSubIndexType
-CSharpMath.Editor.MathListSubIndexType.Radicand = 6 -> CSharpMath.Editor.MathListSubIndexType
-CSharpMath.Editor.MathListSubIndexType.Subscript = 3 -> CSharpMath.Editor.MathListSubIndexType
-CSharpMath.Editor.MathListSubIndexType.Superscript = 2 -> CSharpMath.Editor.MathListSubIndexType
+CSharpMath.Editor.MathListSubIndexType.BetweenBaseAndScripts = 0 -> CSharpMath.Editor.MathListSubIndexType
+CSharpMath.Editor.MathListSubIndexType.Degree = 6 -> CSharpMath.Editor.MathListSubIndexType
+CSharpMath.Editor.MathListSubIndexType.Denominator = 4 -> CSharpMath.Editor.MathListSubIndexType
+CSharpMath.Editor.MathListSubIndexType.Inner = 7 -> CSharpMath.Editor.MathListSubIndexType
+CSharpMath.Editor.MathListSubIndexType.Numerator = 3 -> CSharpMath.Editor.MathListSubIndexType
+CSharpMath.Editor.MathListSubIndexType.Radicand = 5 -> CSharpMath.Editor.MathListSubIndexType
+CSharpMath.Editor.MathListSubIndexType.Subscript = 2 -> CSharpMath.Editor.MathListSubIndexType
+CSharpMath.Editor.MathListSubIndexType.Superscript = 1 -> CSharpMath.Editor.MathListSubIndexType
 CSharpMath.Editor.SubIndexTypeMismatchException
-CSharpMath.Editor.SubIndexTypeMismatchException.SubIndexTypeMismatchException(CSharpMath.Editor.MathListIndex! index) -> void
-CSharpMath.Editor.SubIndexTypeMismatchException.SubIndexTypeMismatchException(System.Type! atomType, CSharpMath.Editor.MathListIndex! index) -> void
+CSharpMath.Editor.SubIndexTypeMismatchException.SubIndexTypeMismatchException(string! target, int atomIndex) -> void
 CSharpMath.Extensions
 override CSharpMath.Atom.Atoms.Accent.DebugString.get -> string!
 override CSharpMath.Atom.Atoms.Accent.Equals(object! obj) -> bool
@@ -1091,8 +1090,7 @@ override CSharpMath.Display.Displays.RadicalDisplay<TFont, TGlyph>.ToString() ->
 override CSharpMath.Display.Displays.TextLineDisplay<TFont, TGlyph>.ToString() -> string!
 override CSharpMath.Display.Displays.TextRunDisplay<TFont, TGlyph>.ToString() -> string!
 override CSharpMath.Display.GlyphPart<TGlyph>.ToString() -> string!
-override CSharpMath.Editor.MathListIndex.Equals(object! obj) -> bool
-override CSharpMath.Editor.MathListIndex.GetHashCode() -> int
+override CSharpMath.Editor.MathListIndex.Equals(object? obj) -> bool
 override CSharpMath.Editor.MathListIndex.ToString() -> string!
 override CSharpMath.Editor.MathListRange.ToString() -> string!
 static CSharpMath.Atom.Boundary.operator !=(CSharpMath.Atom.Boundary left, CSharpMath.Atom.Boundary right) -> bool
@@ -1192,15 +1190,15 @@ static CSharpMath.Editor.Extensions.HighlightCharacterAt<TFont, TGlyph>(this CSh
 static CSharpMath.Editor.Extensions.HighlightCharacterAt<TFont, TGlyph>(this CSharpMath.Display.Displays.TextLineDisplay<TFont, TGlyph>! self, CSharpMath.Editor.MathListIndex! index, System.Drawing.Color color) -> void
 static CSharpMath.Editor.Extensions.HighlightCharacterAt<TFont, TGlyph>(this CSharpMath.Display.IDisplay<TFont, TGlyph>! display, CSharpMath.Editor.MathListIndex! index, System.Drawing.Color color) -> void
 static CSharpMath.Editor.Extensions.HighlightCharacterAt<TFont, TGlyph>(this CSharpMath.Display.IGlyphDisplay<TFont, TGlyph>! self, CSharpMath.Editor.MathListIndex! index, System.Drawing.Color color) -> void
-static CSharpMath.Editor.Extensions.IndexForPoint<TFont, TGlyph>(this CSharpMath.Display.Displays.FractionDisplay<TFont, TGlyph>! self, CSharpMath.Display.FrontEnd.TypesettingContext<TFont, TGlyph>! context, System.Drawing.PointF point) -> CSharpMath.Editor.MathListIndex!
-static CSharpMath.Editor.Extensions.IndexForPoint<TFont, TGlyph>(this CSharpMath.Display.Displays.InnerDisplay<TFont, TGlyph>! self, CSharpMath.Display.FrontEnd.TypesettingContext<TFont, TGlyph>! context, System.Drawing.PointF point) -> CSharpMath.Editor.MathListIndex!
-static CSharpMath.Editor.Extensions.IndexForPoint<TFont, TGlyph>(this CSharpMath.Display.Displays.LargeOpLimitsDisplay<TFont, TGlyph>! self, CSharpMath.Display.FrontEnd.TypesettingContext<TFont, TGlyph>! context, System.Drawing.PointF point) -> CSharpMath.Editor.MathListIndex!
+static CSharpMath.Editor.Extensions.IndexForPoint<TFont, TGlyph>(this CSharpMath.Display.Displays.FractionDisplay<TFont, TGlyph>! self, CSharpMath.Display.FrontEnd.TypesettingContext<TFont, TGlyph>! context, System.Drawing.PointF point) -> CSharpMath.Editor.MathListIndex?
+static CSharpMath.Editor.Extensions.IndexForPoint<TFont, TGlyph>(this CSharpMath.Display.Displays.InnerDisplay<TFont, TGlyph>! self, CSharpMath.Display.FrontEnd.TypesettingContext<TFont, TGlyph>! context, System.Drawing.PointF point) -> CSharpMath.Editor.MathListIndex?
+static CSharpMath.Editor.Extensions.IndexForPoint<TFont, TGlyph>(this CSharpMath.Display.Displays.LargeOpLimitsDisplay<TFont, TGlyph>! self, CSharpMath.Display.FrontEnd.TypesettingContext<TFont, TGlyph>! context, System.Drawing.PointF point) -> CSharpMath.Editor.MathListIndex?
 static CSharpMath.Editor.Extensions.IndexForPoint<TFont, TGlyph>(this CSharpMath.Display.Displays.ListDisplay<TFont, TGlyph>! self, CSharpMath.Display.FrontEnd.TypesettingContext<TFont, TGlyph>! context, System.Drawing.PointF point) -> CSharpMath.Editor.MathListIndex?
-static CSharpMath.Editor.Extensions.IndexForPoint<TFont, TGlyph>(this CSharpMath.Display.Displays.RadicalDisplay<TFont, TGlyph>! self, CSharpMath.Display.FrontEnd.TypesettingContext<TFont, TGlyph>! context, System.Drawing.PointF point) -> CSharpMath.Editor.MathListIndex!
+static CSharpMath.Editor.Extensions.IndexForPoint<TFont, TGlyph>(this CSharpMath.Display.Displays.RadicalDisplay<TFont, TGlyph>! self, CSharpMath.Display.FrontEnd.TypesettingContext<TFont, TGlyph>! context, System.Drawing.PointF point) -> CSharpMath.Editor.MathListIndex?
 static CSharpMath.Editor.Extensions.IndexForPoint<TFont, TGlyph>(this CSharpMath.Display.Displays.TextLineDisplay<TFont, TGlyph>! self, CSharpMath.Display.FrontEnd.TypesettingContext<TFont, TGlyph>! context, System.Drawing.PointF point) -> CSharpMath.Editor.MathListIndex?
 static CSharpMath.Editor.Extensions.IndexForPoint<TFont, TGlyph>(this CSharpMath.Display.IDisplay<TFont, TGlyph>! display, CSharpMath.Display.FrontEnd.TypesettingContext<TFont, TGlyph>! context, System.Drawing.PointF point) -> CSharpMath.Editor.MathListIndex?
 static CSharpMath.Editor.Extensions.IndexForPoint<TFont, TGlyph>(this CSharpMath.Display.IGlyphDisplay<TFont, TGlyph>! self, CSharpMath.Display.FrontEnd.TypesettingContext<TFont, TGlyph>! _, System.Drawing.PointF point) -> CSharpMath.Editor.MathListIndex!
-static CSharpMath.Editor.Extensions.InsertAndAdvance(this CSharpMath.Atom.MathList! self, ref CSharpMath.Editor.MathListIndex! index, CSharpMath.Atom.MathAtom! atom, CSharpMath.Editor.MathListSubIndexType advanceType) -> void
+static CSharpMath.Editor.Extensions.InsertAndAdvance(this CSharpMath.Atom.MathList! self, CSharpMath.Editor.MathListIndex! index, CSharpMath.Atom.MathAtom! atom, CSharpMath.Editor.MathListSubIndexType? advanceType) -> CSharpMath.Editor.MathListIndex!
 static CSharpMath.Editor.Extensions.MathListIndexToStringIndex<TFont, TGlyph>(this CSharpMath.Display.Displays.TextLineDisplay<TFont, TGlyph>! self, int mlIndex) -> int
 static CSharpMath.Editor.Extensions.PointForIndex<TFont, TGlyph>(this CSharpMath.Display.Displays.FractionDisplay<TFont, TGlyph>! self, CSharpMath.Display.FrontEnd.TypesettingContext<TFont, TGlyph>! _, CSharpMath.Editor.MathListIndex! index) -> System.Drawing.PointF?
 static CSharpMath.Editor.Extensions.PointForIndex<TFont, TGlyph>(this CSharpMath.Display.Displays.InnerDisplay<TFont, TGlyph>! self, CSharpMath.Display.FrontEnd.TypesettingContext<TFont, TGlyph>! _, CSharpMath.Editor.MathListIndex! index) -> System.Drawing.PointF?
@@ -1210,15 +1208,15 @@ static CSharpMath.Editor.Extensions.PointForIndex<TFont, TGlyph>(this CSharpMath
 static CSharpMath.Editor.Extensions.PointForIndex<TFont, TGlyph>(this CSharpMath.Display.Displays.TextLineDisplay<TFont, TGlyph>! self, CSharpMath.Display.FrontEnd.TypesettingContext<TFont, TGlyph>! context, CSharpMath.Editor.MathListIndex! index) -> System.Drawing.PointF?
 static CSharpMath.Editor.Extensions.PointForIndex<TFont, TGlyph>(this CSharpMath.Display.IDisplay<TFont, TGlyph>! display, CSharpMath.Display.FrontEnd.TypesettingContext<TFont, TGlyph>! context, CSharpMath.Editor.MathListIndex! index) -> System.Drawing.PointF?
 static CSharpMath.Editor.Extensions.PointForIndex<TFont, TGlyph>(this CSharpMath.Display.IGlyphDisplay<TFont, TGlyph>! self, CSharpMath.Display.FrontEnd.TypesettingContext<TFont, TGlyph>! _, CSharpMath.Editor.MathListIndex! index) -> System.Drawing.PointF?
-static CSharpMath.Editor.Extensions.RemoveAt(this CSharpMath.Atom.MathList! self, ref CSharpMath.Editor.MathListIndex! index) -> void
+static CSharpMath.Editor.Extensions.RemoveAt(this CSharpMath.Atom.MathList! self, CSharpMath.Editor.MathListIndex! index) -> CSharpMath.Editor.MathListIndex!
 static CSharpMath.Editor.Extensions.RemoveAtoms(this CSharpMath.Atom.MathList! self, CSharpMath.Editor.MathListRange? nullableRange) -> void
 static CSharpMath.Editor.Extensions.StringIndexToCodepointIndex(System.Text.StringBuilder! str, int stringIndex) -> int
 static CSharpMath.Editor.Extensions.StringIndexToMathListIndex<TFont, TGlyph>(this CSharpMath.Display.Displays.TextLineDisplay<TFont, TGlyph>! self, int strIndex) -> int
 static CSharpMath.Editor.Extensions.SubDisplayForIndex<TFont, TGlyph>(this CSharpMath.Display.Displays.ListDisplay<TFont, TGlyph>! self, CSharpMath.Editor.MathListIndex! index) -> CSharpMath.Display.IDisplay<TFont, TGlyph>?
 static CSharpMath.Editor.Extensions.SubListForIndexType<TFont, TGlyph>(this CSharpMath.Display.Displays.LargeOpLimitsDisplay<TFont, TGlyph>! self, CSharpMath.Editor.MathListSubIndexType type) -> CSharpMath.Display.IDisplay<TFont, TGlyph>?
 static CSharpMath.Editor.Extensions.XOffsetForGlyphIndex<TFont, TGlyph>(this CSharpMath.Display.AttributedGlyphRun<TFont, TGlyph>! line, CSharpMath.Display.FrontEnd.TypesettingContext<TFont, TGlyph>! context, int index) -> float
-static CSharpMath.Editor.MathListIndex.IndexAtLocation(int location, CSharpMath.Editor.MathListSubIndexType type, CSharpMath.Editor.MathListIndex? subIndex) -> CSharpMath.Editor.MathListIndex!
-static CSharpMath.Editor.MathListIndex.Level0Index(int index) -> CSharpMath.Editor.MathListIndex!
+static CSharpMath.Editor.MathListIndex.operator !=(CSharpMath.Editor.MathListIndex? left, CSharpMath.Editor.MathListIndex? right) -> bool
+static CSharpMath.Editor.MathListIndex.operator ==(CSharpMath.Editor.MathListIndex? left, CSharpMath.Editor.MathListIndex? right) -> bool
 static CSharpMath.Editor.MathListRange.Combine(System.Collections.Generic.IEnumerable<CSharpMath.Editor.MathListRange>! ranges) -> CSharpMath.Editor.MathListRange
 static CSharpMath.Editor.MathListRange.operator +(CSharpMath.Editor.MathListRange left, CSharpMath.Editor.MathListRange right) -> CSharpMath.Editor.MathListRange
 static CSharpMath.Extensions.Append(this System.Text.StringBuilder! sb, System.ReadOnlySpan<char> value) -> System.Text.StringBuilder!
@@ -1273,3 +1271,7 @@ virtual CSharpMath.Atom.SpanResult<T>.Func<TResult>.Invoke(System.ReadOnlySpan<T
 virtual CSharpMath.Display.FrontEnd.FontMathTable<TFont, TGlyph>.FractionDelimiterDisplayStyleSize(TFont font) -> float
 virtual CSharpMath.Display.FrontEnd.FontMathTable<TFont, TGlyph>.FractionDelimiterSize(TFont font) -> float
 virtual CSharpMath.Editor.MathKeyboard<TFont, TGlyph>.Measure.get -> System.Drawing.RectangleF
+virtual CSharpMath.Editor.MathListIndex.<Clone>$() -> CSharpMath.Editor.MathListIndex!
+virtual CSharpMath.Editor.MathListIndex.EqualityContract.get -> System.Type!
+virtual CSharpMath.Editor.MathListIndex.Equals(CSharpMath.Editor.MathListIndex? other) -> bool
+virtual CSharpMath.Editor.MathListIndex.PrintMembers(System.Text.StringBuilder! builder) -> bool


### PR DESCRIPTION
Currently MathListIndex is supposed to have a SubIndex if an only if SubIndexType <> MathListSubIndexType.None. (Can you confirm that @Happypig375 ?)

This PR brings this constraint into the type structure, removing `MathListSubIndexType.None` and having:

```csharp
public (MathListSubIndexType SubIndexType, MathListIndex SubIndex)? SubIndexInfo;
```