### PR TITLE
Make blinking Placeholder's Nucleus and ForeColor customizable in both CaretStates

### DIFF
--- a/CSharpMath.CoreTests/MockTests.cs
+++ b/CSharpMath.CoreTests/MockTests.cs
@@ -2,6 +2,7 @@ using CSharpMath.CoreTests.FrontEnd;
 using Xunit;
 using TGlyph = System.Char;
 using CSharpMath.Display;
+using System.Linq;
 
 namespace CSharpMath.CoreTests {
   // purpose of this class is to make sure our mocks behave as expected.
@@ -12,6 +13,7 @@ namespace CSharpMath.CoreTests {
       var font = new TestFont(10);
       var provider = TestGlyphBoundsProvider.Instance;
       var glyphRun = new AttributedGlyphRun<TestFont, TGlyph>(hello, hello, font);
+      Assert.True(glyphRun.GlyphInfos.All(GlyphInfo => GlyphInfo.Foreground == null));
       var width = provider.GetTypographicWidth(font, glyphRun);
       Approximately.Equal(width, 25,  0.01);
     }
@@ -22,6 +24,7 @@ namespace CSharpMath.CoreTests {
       var font = new TestFont(10);
       var provider = TestGlyphBoundsProvider.Instance;
       var glyphRun = new AttributedGlyphRun<TestFont, TGlyph>(america, america, font);
+      Assert.True(glyphRun.GlyphInfos.All(GlyphInfo => GlyphInfo.Foreground == null));
       var width = provider.GetTypographicWidth(font, glyphRun);
       Approximately.Equal(width, 40, 0.01);
     }

--- a/CSharpMath.CoreTests/MockTests.cs
+++ b/CSharpMath.CoreTests/MockTests.cs
@@ -13,7 +13,7 @@ namespace CSharpMath.CoreTests {
       var font = new TestFont(10);
       var provider = TestGlyphBoundsProvider.Instance;
       var glyphRun = new AttributedGlyphRun<TestFont, TGlyph>(hello, hello, font);
-      Assert.True(glyphRun.GlyphInfos.All(GlyphInfo => GlyphInfo.Foreground == null));
+      Assert.All(glyphRun.GlyphInfos, glyphInfo => Assert.Null(glyphInfo.Foreground));
       var width = provider.GetTypographicWidth(font, glyphRun);
       Approximately.Equal(width, 25,  0.01);
     }
@@ -24,7 +24,7 @@ namespace CSharpMath.CoreTests {
       var font = new TestFont(10);
       var provider = TestGlyphBoundsProvider.Instance;
       var glyphRun = new AttributedGlyphRun<TestFont, TGlyph>(america, america, font);
-      Assert.True(glyphRun.GlyphInfos.All(GlyphInfo => GlyphInfo.Foreground == null));
+      Assert.All(glyphRun.GlyphInfos, glyphInfo => Assert.Null(glyphInfo.Foreground));
       var width = provider.GetTypographicWidth(font, glyphRun);
       Approximately.Equal(width, 40, 0.01);
     }

--- a/CSharpMath.CoreTests/MockTests.cs
+++ b/CSharpMath.CoreTests/MockTests.cs
@@ -2,7 +2,6 @@ using CSharpMath.CoreTests.FrontEnd;
 using Xunit;
 using TGlyph = System.Char;
 using CSharpMath.Display;
-using System.Linq;
 
 namespace CSharpMath.CoreTests {
   // purpose of this class is to make sure our mocks behave as expected.
@@ -17,7 +16,6 @@ namespace CSharpMath.CoreTests {
       var width = provider.GetTypographicWidth(font, glyphRun);
       Approximately.Equal(width, 25,  0.01);
     }
-
     [Fact]
     public void TestGlyphBoundsWithM() {
       string america = "America";

--- a/CSharpMath.Editor.Tests/CaretTests.cs
+++ b/CSharpMath.Editor.Tests/CaretTests.cs
@@ -206,6 +206,14 @@ namespace CSharpMath.Editor.Tests {
       Assert.Equal(System.Drawing.Color.Blue, outer.Color);
       Assert.Equal("😐", inner.Nucleus);
       Assert.Equal(System.Drawing.Color.Blue, inner.Color);
+
+      await Task.Delay((int)MathKeyboard<TestFont, char>.DefaultBlinkMilliseconds + CaretBlinks.MillisecondBuffer);
+      Assert.Equal(MathKeyboardCaretState.ShownThroughPlaceholder, keyboard.CaretState);
+      Assert.Equal("😐", outer.Nucleus);
+      Assert.Equal(System.Drawing.Color.Blue, outer.Color);
+      Assert.Equal("😀", inner.Nucleus);
+      Assert.Equal(System.Drawing.Color.Green, inner.Color);
+
       RestorePlaceholderDefaultSettings();
     }
     [Fact]

--- a/CSharpMath.Editor.Tests/CaretTests.cs
+++ b/CSharpMath.Editor.Tests/CaretTests.cs
@@ -177,6 +177,7 @@ namespace CSharpMath.Editor.Tests {
       Assert.Equal(MathKeyboardCaretState.Shown, keyboard.CaretState);
     }
   }
+  [Collection(nameof(NonParallelPlaceholderTests))]
   public class CustomizablePlaceholder {
     [Fact]
     public async void Test() {
@@ -210,6 +211,11 @@ namespace CSharpMath.Editor.Tests {
     [Fact]
     public void LaTeXSettings_Placeholder_IsNewInstance() {
       Assert.False(LaTeXSettings.Placeholder == LaTeXSettings.Placeholder);
+      // Double check, also verify that its contents are 'fresh':
+      LaTeXSettings.Placeholder.Nucleus = "x";
+      Assert.NotEqual("x", LaTeXSettings.Placeholder.Nucleus);
+      LaTeXSettings.Placeholder.Color = System.Drawing.Color.Green;
+      Assert.NotEqual(System.Drawing.Color.Green, LaTeXSettings.Placeholder.Color);
     }
     [Fact]
     public void DefaultPlaceholderAppearance() {
@@ -237,4 +243,6 @@ namespace CSharpMath.Editor.Tests {
       LaTeXSettings.PlaceholderRestingColor = null;
     }
   }
+  [CollectionDefinition(nameof(NonParallelPlaceholderTests), DisableParallelization = true)]
+  public class NonParallelPlaceholderTests { }
 }

--- a/CSharpMath.Editor.Tests/CaretTests.cs
+++ b/CSharpMath.Editor.Tests/CaretTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using CSharpMath.Atom;
 using CSharpMath.CoreTests.FrontEnd;
@@ -33,18 +32,18 @@ namespace CSharpMath.Editor.Tests {
       var outer = Assert.IsType<Atom.Atoms.Placeholder>(Assert.Single(keyboard.MathList));
       var inner = Assert.IsType<Atom.Atoms.Placeholder>(Assert.Single(outer.Superscript));
       Assert.Equal(MathKeyboardCaretState.ShownThroughPlaceholder, keyboard.CaretState);
-      Assert.Equal(CustomizablePlaceholder.RestingNucleusDefault, outer.Nucleus);
-      Assert.Equal(CustomizablePlaceholder.ActiveNucleusDefault, inner.Nucleus);
+      Assert.Equal(DefaultPlaceholderSettings.RestingNucleus, outer.Nucleus);
+      Assert.Equal(DefaultPlaceholderSettings.ActiveNucleus, inner.Nucleus);
 
       await Task.Delay((int)MathKeyboard<TestFont, char>.DefaultBlinkMilliseconds + CaretBlinks.MillisecondBuffer);
       Assert.Equal(MathKeyboardCaretState.TemporarilyHidden, keyboard.CaretState);
-      Assert.Equal(CustomizablePlaceholder.RestingNucleusDefault, outer.Nucleus);
-      Assert.Equal(CustomizablePlaceholder.RestingNucleusDefault, inner.Nucleus);
+      Assert.Equal(DefaultPlaceholderSettings.RestingNucleus, outer.Nucleus);
+      Assert.Equal(DefaultPlaceholderSettings.RestingNucleus, inner.Nucleus);
 
       await Task.Delay((int)MathKeyboard<TestFont, char>.DefaultBlinkMilliseconds + CaretBlinks.MillisecondBuffer);
       Assert.Equal(MathKeyboardCaretState.ShownThroughPlaceholder, keyboard.CaretState);
-      Assert.Equal(CustomizablePlaceholder.RestingNucleusDefault, outer.Nucleus);
-      Assert.Equal(CustomizablePlaceholder.ActiveNucleusDefault, inner.Nucleus);
+      Assert.Equal(DefaultPlaceholderSettings.RestingNucleus, outer.Nucleus);
+      Assert.Equal(DefaultPlaceholderSettings.ActiveNucleus, inner.Nucleus);
     }
   }
   public class CaretMovesWithPlaceholder {
@@ -59,20 +58,20 @@ namespace CSharpMath.Editor.Tests {
       var outer = Assert.IsType<Atom.Atoms.Placeholder>(Assert.Single(keyboard.MathList));
       var inner = Assert.IsType<Atom.Atoms.Placeholder>(Assert.Single(outer.Subscript));
       Assert.Equal(MathKeyboardCaretState.ShownThroughPlaceholder, keyboard.CaretState);
-      Assert.Equal(CustomizablePlaceholder.RestingNucleusDefault, outer.Nucleus);
-      Assert.Equal(CustomizablePlaceholder.ActiveNucleusDefault, inner.Nucleus);
+      Assert.Equal(DefaultPlaceholderSettings.RestingNucleus, outer.Nucleus);
+      Assert.Equal(DefaultPlaceholderSettings.ActiveNucleus, inner.Nucleus);
 
       await Task.Delay((int)MathKeyboard<TestFont, char>.DefaultBlinkMilliseconds + CaretBlinks.MillisecondBuffer);
       Assert.Equal(MathKeyboardCaretState.TemporarilyHidden, keyboard.CaretState);
       keyboard.KeyPress(MathKeyboardInput.Left);
       Assert.Equal(MathKeyboardCaretState.ShownThroughPlaceholder, keyboard.CaretState);
-      Assert.Equal(CustomizablePlaceholder.ActiveNucleusDefault, outer.Nucleus);
-      Assert.Equal(CustomizablePlaceholder.RestingNucleusDefault, inner.Nucleus);
+      Assert.Equal(DefaultPlaceholderSettings.ActiveNucleus, outer.Nucleus);
+      Assert.Equal(DefaultPlaceholderSettings.RestingNucleus, inner.Nucleus);
 
       Assert.Equal(MathKeyboardCaretState.ShownThroughPlaceholder, keyboard.CaretState);
       keyboard.KeyPress(MathKeyboardInput.Right);
-      Assert.Equal(CustomizablePlaceholder.RestingNucleusDefault, outer.Nucleus);
-      Assert.Equal(CustomizablePlaceholder.ActiveNucleusDefault, inner.Nucleus);
+      Assert.Equal(DefaultPlaceholderSettings.RestingNucleus, outer.Nucleus);
+      Assert.Equal(DefaultPlaceholderSettings.ActiveNucleus, inner.Nucleus);
     }
   }
   public class CaretStaysHidden {
@@ -177,19 +176,51 @@ namespace CSharpMath.Editor.Tests {
       Assert.Equal(MathKeyboardCaretState.Shown, keyboard.CaretState);
     }
   }
+  public class DefaultPlaceholderSettings {
+    public const string ActiveNucleus = "■";
+    public const string RestingNucleus = "□";
+    public static readonly System.Drawing.Color? ActiveColor = null;
+    public static readonly System.Drawing.Color? RestingColor = null;
+  }
+  [CollectionDefinition(nameof(NonParallelPlaceholderTests), DisableParallelization = true)]
+  public class NonParallelPlaceholderTests { }
   [Collection(nameof(NonParallelPlaceholderTests))]
-  public class CustomizablePlaceholder {
-    public const string ActiveNucleusDefault = "\u25A0";
-    public const string RestingNucleusDefault = "\u25A1";
-    public static readonly System.Drawing.Color? RestingColorDefault = null;
-    public static readonly System.Drawing.Color? ActiveColorDefault = null;
+  public class DefaultPlaceholder {
     [Fact]
-    public async void CustomizedPlaceholderBlinks() {
+    public void LaTeXSettingsPlaceholderIsNewInstance() {
+      Assert.False(LaTeXSettings.Placeholder == LaTeXSettings.Placeholder);
+      // Double check, also verify that its contents are 'fresh':
+      LaTeXSettings.Placeholder.Nucleus = "x";
+      Assert.Equal(DefaultPlaceholderSettings.RestingNucleus, LaTeXSettings.Placeholder.Nucleus);
+      LaTeXSettings.Placeholder.Color = System.Drawing.Color.Green;
+      Assert.Equal(DefaultPlaceholderSettings.RestingColor, LaTeXSettings.Placeholder.Color);
+    }
+    [Fact]
+    public void DefaultPlaceholderAppearance() {
+      Assert.Null(LaTeXSettings.PlaceholderActiveColor);
+      Assert.Null(LaTeXSettings.PlaceholderRestingColor);
+      Assert.Equal(DefaultPlaceholderSettings.ActiveNucleus, LaTeXSettings.PlaceholderActiveNucleus);
+      Assert.Equal(DefaultPlaceholderSettings.RestingNucleus, LaTeXSettings.PlaceholderRestingNucleus);
+      Assert.Equal(LaTeXSettings.PlaceholderRestingNucleus, LaTeXSettings.Placeholder.Nucleus);
+      Assert.Equal(LaTeXSettings.PlaceholderRestingColor, LaTeXSettings.Placeholder.Color);
+    }
+  }
+  [Collection(nameof(NonParallelPlaceholderTests))]
+  public class CustomizablePlaceholder : IDisposable {
+    public CustomizablePlaceholder() {
       LaTeXSettings.PlaceholderActiveNucleus = "😀";
       LaTeXSettings.PlaceholderRestingNucleus = "😐";
       LaTeXSettings.PlaceholderActiveColor = System.Drawing.Color.Green;
       LaTeXSettings.PlaceholderRestingColor = System.Drawing.Color.Blue;
-
+    }
+    public void Dispose() {
+      LaTeXSettings.PlaceholderActiveNucleus = DefaultPlaceholderSettings.ActiveNucleus;
+      LaTeXSettings.PlaceholderRestingNucleus = DefaultPlaceholderSettings.RestingNucleus;
+      LaTeXSettings.PlaceholderActiveColor = DefaultPlaceholderSettings.ActiveColor;
+      LaTeXSettings.PlaceholderRestingColor = DefaultPlaceholderSettings.RestingColor;
+    }
+    [Fact]
+    public async void CustomizedPlaceholderBlinks() {
       var keyboard = new MathKeyboard<TestFont, char>(TestTypesettingContexts.Instance, new TestFont()) {
         CaretState = MathKeyboardCaretState.Shown
       };
@@ -217,15 +248,9 @@ namespace CSharpMath.Editor.Tests {
       Assert.Equal(System.Drawing.Color.Blue, outer.Color);
       Assert.Equal("😀", inner.Nucleus);
       Assert.Equal(System.Drawing.Color.Green, inner.Color);
-
-      RestorePlaceholderDefaultSettings();
     }
     [Fact]
     public void AllCustomizablePlaceholderPropertiesAreResetOnCaretVisible() {
-      LaTeXSettings.PlaceholderActiveNucleus = "😀";
-      LaTeXSettings.PlaceholderRestingNucleus = "😐";
-      LaTeXSettings.PlaceholderActiveColor = System.Drawing.Color.Green;
-      LaTeXSettings.PlaceholderRestingColor = System.Drawing.Color.Blue;
       var keyboard = new MathKeyboard<TestFont, char>(TestTypesettingContexts.Instance, new TestFont()) {
         CaretState = MathKeyboardCaretState.Shown
       };
@@ -241,43 +266,11 @@ namespace CSharpMath.Editor.Tests {
       Assert.Equal(LaTeXSettings.PlaceholderRestingColor, outer.Color);
       Assert.Equal(LaTeXSettings.PlaceholderRestingNucleus, inner.Nucleus);
       Assert.Equal(LaTeXSettings.PlaceholderRestingColor, inner.Color);
-      RestorePlaceholderDefaultSettings();
-    }
-    [Fact]
-    public void LaTeXSettings_Placeholder_IsNewInstance() {
-      Assert.False(LaTeXSettings.Placeholder == LaTeXSettings.Placeholder);
-      // Double check, also verify that its contents are 'fresh':
-      LaTeXSettings.Placeholder.Nucleus = "x";
-      Assert.Equal(RestingNucleusDefault, LaTeXSettings.Placeholder.Nucleus);
-      LaTeXSettings.Placeholder.Color = System.Drawing.Color.Green;
-      Assert.Equal(RestingColorDefault, LaTeXSettings.Placeholder.Color);
-    }
-    [Fact]
-    public void DefaultPlaceholderAppearance() {
-      Assert.Null(LaTeXSettings.PlaceholderActiveColor);
-      Assert.Null(LaTeXSettings.PlaceholderRestingColor);
-      Assert.Equal(ActiveNucleusDefault, LaTeXSettings.PlaceholderActiveNucleus);
-      Assert.Equal(RestingNucleusDefault, LaTeXSettings.PlaceholderRestingNucleus);
-      Assert.Equal(LaTeXSettings.PlaceholderRestingNucleus, LaTeXSettings.Placeholder.Nucleus);
-      Assert.Equal(LaTeXSettings.PlaceholderRestingColor, LaTeXSettings.Placeholder.Color);
     }
     [Fact]
     public void CustomizedPlaceholderGetter() {
-      LaTeXSettings.PlaceholderActiveNucleus = "😀";
-      LaTeXSettings.PlaceholderRestingNucleus = "😐";
-      LaTeXSettings.PlaceholderActiveColor = System.Drawing.Color.Green;
-      LaTeXSettings.PlaceholderRestingColor = System.Drawing.Color.Blue;
       Assert.Equal("😐", LaTeXSettings.Placeholder.Nucleus);
       Assert.Equal(System.Drawing.Color.Blue, LaTeXSettings.Placeholder.Color);
-      RestorePlaceholderDefaultSettings();
-    }
-    private void RestorePlaceholderDefaultSettings() {
-      LaTeXSettings.PlaceholderActiveNucleus = ActiveNucleusDefault;
-      LaTeXSettings.PlaceholderRestingNucleus = RestingNucleusDefault;
-      LaTeXSettings.PlaceholderActiveColor = ActiveColorDefault;
-      LaTeXSettings.PlaceholderRestingColor = RestingColorDefault;
     }
   }
-  [CollectionDefinition(nameof(NonParallelPlaceholderTests), DisableParallelization = true)]
-  public class NonParallelPlaceholderTests { }
 }

--- a/CSharpMath.Editor.Tests/CaretTests.cs
+++ b/CSharpMath.Editor.Tests/CaretTests.cs
@@ -138,14 +138,16 @@ namespace CSharpMath.Editor.Tests {
       Assert.Equal(MathKeyboardCaretState.Shown, keyboard.CaretState);
       await Task.Delay((int)MathKeyboard<TestFont, char>.DefaultBlinkMilliseconds - CaretBlinks.MillisecondBuffer);
 
-      keyboard.KeyPress(MathKeyboardInput.A);
       Assert.Equal(MathKeyboardCaretState.Shown, keyboard.CaretState);
+      keyboard.KeyPress(MathKeyboardInput.A);
       await Task.Delay((int)MathKeyboard<TestFont, char>.DefaultBlinkMilliseconds - CaretBlinks.MillisecondBuffer);
 
-      keyboard.KeyPress(MathKeyboardInput.Left);
       Assert.Equal(MathKeyboardCaretState.Shown, keyboard.CaretState);
+      keyboard.KeyPress(MathKeyboardInput.Left);
+      await Task.Delay((int)MathKeyboard<TestFont, char>.DefaultBlinkMilliseconds - CaretBlinks.MillisecondBuffer);
 
-      await Task.Delay((int)MathKeyboard<TestFont, char>.DefaultBlinkMilliseconds + 4 * CaretBlinks.MillisecondBuffer);
+      Assert.Equal(MathKeyboardCaretState.Shown, keyboard.CaretState);
+      await Task.Delay(4 * CaretBlinks.MillisecondBuffer);
       Assert.Equal(MathKeyboardCaretState.TemporarilyHidden, keyboard.CaretState);
     }
   }

--- a/CSharpMath.Editor.Tests/CaretTests.cs
+++ b/CSharpMath.Editor.Tests/CaretTests.cs
@@ -180,7 +180,7 @@ namespace CSharpMath.Editor.Tests {
   [Collection(nameof(NonParallelPlaceholderTests))]
   public class CustomizablePlaceholder {
     [Fact]
-    public async void Test() {
+    public async void CustomizedPlaceholderBlinks() {
       LaTeXSettings.PlaceholderActiveNucleus = "😀";
       LaTeXSettings.PlaceholderRestingNucleus = "😐";
       LaTeXSettings.PlaceholderActiveColor = System.Drawing.Color.Green;
@@ -206,6 +206,29 @@ namespace CSharpMath.Editor.Tests {
       Assert.Equal(System.Drawing.Color.Blue, outer.Color);
       Assert.Equal("😐", inner.Nucleus);
       Assert.Equal(System.Drawing.Color.Blue, inner.Color);
+      RestorePlaceholderDefaultSettings();
+    }
+    [Fact]
+    public void AllCustomizablePlaceholderPropertiesAreResetOnCaretVisible() {
+      LaTeXSettings.PlaceholderActiveNucleus = "😀";
+      LaTeXSettings.PlaceholderRestingNucleus = "😐";
+      LaTeXSettings.PlaceholderActiveColor = System.Drawing.Color.Green;
+      LaTeXSettings.PlaceholderRestingColor = System.Drawing.Color.Blue;
+      var keyboard = new MathKeyboard<TestFont, char>(TestTypesettingContexts.Instance, new TestFont()) {
+        CaretState = MathKeyboardCaretState.Shown
+      };
+      Assert.Equal(MathKeyboardCaretState.Shown, keyboard.CaretState);
+      keyboard.KeyPress(MathKeyboardInput.Subscript);
+      var outer = Assert.IsType<Atom.Atoms.Placeholder>(Assert.Single(keyboard.MathList));
+      var inner = Assert.IsType<Atom.Atoms.Placeholder>(Assert.Single(outer.Subscript));
+      Assert.Equal(MathKeyboardCaretState.ShownThroughPlaceholder, keyboard.CaretState);
+
+      keyboard.InsertionIndex = MathListIndex.Level0Index(keyboard.MathList.Count);
+      Assert.Equal(MathKeyboardCaretState.Shown, keyboard.CaretState);
+      Assert.Equal(LaTeXSettings.PlaceholderRestingNucleus, outer.Nucleus);
+      Assert.Equal(LaTeXSettings.PlaceholderRestingColor, outer.Color);
+      Assert.Equal(LaTeXSettings.PlaceholderRestingNucleus, inner.Nucleus);
+      Assert.Equal(LaTeXSettings.PlaceholderRestingColor, inner.Color);
       RestorePlaceholderDefaultSettings();
     }
     [Fact]

--- a/CSharpMath.Editor.Tests/CaretTests.cs
+++ b/CSharpMath.Editor.Tests/CaretTests.cs
@@ -33,18 +33,18 @@ namespace CSharpMath.Editor.Tests {
       var outer = Assert.IsType<Atom.Atoms.Placeholder>(Assert.Single(keyboard.MathList));
       var inner = Assert.IsType<Atom.Atoms.Placeholder>(Assert.Single(outer.Superscript));
       Assert.Equal(MathKeyboardCaretState.ShownThroughPlaceholder, keyboard.CaretState);
-      Assert.Equal("\u25A1", outer.Nucleus);
-      Assert.Equal("\u25A0", inner.Nucleus);
+      Assert.Equal(CustomizablePlaceholder.RestingNucleusDefault, outer.Nucleus);
+      Assert.Equal(CustomizablePlaceholder.ActiveNucleusDefault, inner.Nucleus);
 
       await Task.Delay((int)MathKeyboard<TestFont, char>.DefaultBlinkMilliseconds + CaretBlinks.MillisecondBuffer);
       Assert.Equal(MathKeyboardCaretState.TemporarilyHidden, keyboard.CaretState);
-      Assert.Equal("\u25A1", outer.Nucleus);
-      Assert.Equal("\u25A1", inner.Nucleus);
+      Assert.Equal(CustomizablePlaceholder.RestingNucleusDefault, outer.Nucleus);
+      Assert.Equal(CustomizablePlaceholder.RestingNucleusDefault, inner.Nucleus);
 
       await Task.Delay((int)MathKeyboard<TestFont, char>.DefaultBlinkMilliseconds + CaretBlinks.MillisecondBuffer);
       Assert.Equal(MathKeyboardCaretState.ShownThroughPlaceholder, keyboard.CaretState);
-      Assert.Equal("\u25A1", outer.Nucleus);
-      Assert.Equal("\u25A0", inner.Nucleus);
+      Assert.Equal(CustomizablePlaceholder.RestingNucleusDefault, outer.Nucleus);
+      Assert.Equal(CustomizablePlaceholder.ActiveNucleusDefault, inner.Nucleus);
     }
   }
   public class CaretMovesWithPlaceholder {
@@ -59,20 +59,20 @@ namespace CSharpMath.Editor.Tests {
       var outer = Assert.IsType<Atom.Atoms.Placeholder>(Assert.Single(keyboard.MathList));
       var inner = Assert.IsType<Atom.Atoms.Placeholder>(Assert.Single(outer.Subscript));
       Assert.Equal(MathKeyboardCaretState.ShownThroughPlaceholder, keyboard.CaretState);
-      Assert.Equal("\u25A1", outer.Nucleus);
-      Assert.Equal("\u25A0", inner.Nucleus);
+      Assert.Equal(CustomizablePlaceholder.RestingNucleusDefault, outer.Nucleus);
+      Assert.Equal(CustomizablePlaceholder.ActiveNucleusDefault, inner.Nucleus);
 
       await Task.Delay((int)MathKeyboard<TestFont, char>.DefaultBlinkMilliseconds + CaretBlinks.MillisecondBuffer);
       Assert.Equal(MathKeyboardCaretState.TemporarilyHidden, keyboard.CaretState);
       keyboard.KeyPress(MathKeyboardInput.Left);
       Assert.Equal(MathKeyboardCaretState.ShownThroughPlaceholder, keyboard.CaretState);
-      Assert.Equal("\u25A0", outer.Nucleus);
-      Assert.Equal("\u25A1", inner.Nucleus);
+      Assert.Equal(CustomizablePlaceholder.ActiveNucleusDefault, outer.Nucleus);
+      Assert.Equal(CustomizablePlaceholder.RestingNucleusDefault, inner.Nucleus);
 
       Assert.Equal(MathKeyboardCaretState.ShownThroughPlaceholder, keyboard.CaretState);
       keyboard.KeyPress(MathKeyboardInput.Right);
-      Assert.Equal("\u25A1", outer.Nucleus);
-      Assert.Equal("\u25A0", inner.Nucleus);
+      Assert.Equal(CustomizablePlaceholder.RestingNucleusDefault, outer.Nucleus);
+      Assert.Equal(CustomizablePlaceholder.ActiveNucleusDefault, inner.Nucleus);
     }
   }
   public class CaretStaysHidden {
@@ -179,6 +179,10 @@ namespace CSharpMath.Editor.Tests {
   }
   [Collection(nameof(NonParallelPlaceholderTests))]
   public class CustomizablePlaceholder {
+    public const string ActiveNucleusDefault = "\u25A0";
+    public const string RestingNucleusDefault = "\u25A1";
+    public static readonly System.Drawing.Color? RestingColorDefault = null;
+    public static readonly System.Drawing.Color? ActiveColorDefault = null;
     [Fact]
     public async void CustomizedPlaceholderBlinks() {
       LaTeXSettings.PlaceholderActiveNucleus = "😀";
@@ -244,16 +248,16 @@ namespace CSharpMath.Editor.Tests {
       Assert.False(LaTeXSettings.Placeholder == LaTeXSettings.Placeholder);
       // Double check, also verify that its contents are 'fresh':
       LaTeXSettings.Placeholder.Nucleus = "x";
-      Assert.NotEqual("x", LaTeXSettings.Placeholder.Nucleus);
+      Assert.Equal(RestingNucleusDefault, LaTeXSettings.Placeholder.Nucleus);
       LaTeXSettings.Placeholder.Color = System.Drawing.Color.Green;
-      Assert.NotEqual(System.Drawing.Color.Green, LaTeXSettings.Placeholder.Color);
+      Assert.Equal(RestingColorDefault, LaTeXSettings.Placeholder.Color);
     }
     [Fact]
     public void DefaultPlaceholderAppearance() {
       Assert.Null(LaTeXSettings.PlaceholderActiveColor);
       Assert.Null(LaTeXSettings.PlaceholderRestingColor);
-      Assert.Equal("\u25A0", LaTeXSettings.PlaceholderActiveNucleus);
-      Assert.Equal("\u25A1", LaTeXSettings.PlaceholderRestingNucleus);
+      Assert.Equal(ActiveNucleusDefault, LaTeXSettings.PlaceholderActiveNucleus);
+      Assert.Equal(RestingNucleusDefault, LaTeXSettings.PlaceholderRestingNucleus);
       Assert.Equal(LaTeXSettings.PlaceholderRestingNucleus, LaTeXSettings.Placeholder.Nucleus);
       Assert.Equal(LaTeXSettings.PlaceholderRestingColor, LaTeXSettings.Placeholder.Color);
     }
@@ -268,10 +272,10 @@ namespace CSharpMath.Editor.Tests {
       RestorePlaceholderDefaultSettings();
     }
     private void RestorePlaceholderDefaultSettings() {
-      LaTeXSettings.PlaceholderActiveNucleus = "\u25A0";
-      LaTeXSettings.PlaceholderRestingNucleus = "\u25A1";
-      LaTeXSettings.PlaceholderActiveColor = null;
-      LaTeXSettings.PlaceholderRestingColor = null;
+      LaTeXSettings.PlaceholderActiveNucleus = ActiveNucleusDefault;
+      LaTeXSettings.PlaceholderRestingNucleus = RestingNucleusDefault;
+      LaTeXSettings.PlaceholderActiveColor = ActiveColorDefault;
+      LaTeXSettings.PlaceholderRestingColor = RestingColorDefault;
     }
   }
   [CollectionDefinition(nameof(NonParallelPlaceholderTests), DisableParallelization = true)]

--- a/CSharpMath.Editor.Tests/CaretTests.cs
+++ b/CSharpMath.Editor.Tests/CaretTests.cs
@@ -138,16 +138,14 @@ namespace CSharpMath.Editor.Tests {
       Assert.Equal(MathKeyboardCaretState.Shown, keyboard.CaretState);
       await Task.Delay((int)MathKeyboard<TestFont, char>.DefaultBlinkMilliseconds - CaretBlinks.MillisecondBuffer);
 
-      Assert.Equal(MathKeyboardCaretState.Shown, keyboard.CaretState);
       keyboard.KeyPress(MathKeyboardInput.A);
+      Assert.Equal(MathKeyboardCaretState.Shown, keyboard.CaretState);
       await Task.Delay((int)MathKeyboard<TestFont, char>.DefaultBlinkMilliseconds - CaretBlinks.MillisecondBuffer);
 
-      Assert.Equal(MathKeyboardCaretState.Shown, keyboard.CaretState);
       keyboard.KeyPress(MathKeyboardInput.Left);
-      await Task.Delay((int)MathKeyboard<TestFont, char>.DefaultBlinkMilliseconds - CaretBlinks.MillisecondBuffer);
-
       Assert.Equal(MathKeyboardCaretState.Shown, keyboard.CaretState);
-      await Task.Delay(4 * CaretBlinks.MillisecondBuffer);
+
+      await Task.Delay((int)MathKeyboard<TestFont, char>.DefaultBlinkMilliseconds + 4 * CaretBlinks.MillisecondBuffer);
       Assert.Equal(MathKeyboardCaretState.TemporarilyHidden, keyboard.CaretState);
     }
   }

--- a/CSharpMath.Editor.Tests/CaretTests.cs
+++ b/CSharpMath.Editor.Tests/CaretTests.cs
@@ -188,7 +188,7 @@ namespace CSharpMath.Editor.Tests {
   public class DefaultPlaceholder {
     [Fact]
     public void LaTeXSettingsPlaceholderIsNewInstance() {
-      Assert.False(LaTeXSettings.Placeholder == LaTeXSettings.Placeholder);
+      Assert.NotSame(LaTeXSettings.Placeholder, LaTeXSettings.Placeholder);
       // Double check, also verify that its contents are 'fresh':
       LaTeXSettings.Placeholder.Nucleus = "x";
       Assert.Equal(DefaultPlaceholderSettings.RestingNucleus, LaTeXSettings.Placeholder.Nucleus);
@@ -220,7 +220,7 @@ namespace CSharpMath.Editor.Tests {
       LaTeXSettings.PlaceholderRestingColor = DefaultPlaceholderSettings.RestingColor;
     }
     [Fact]
-    public async void CustomizedPlaceholderBlinks() {
+    public async Task CustomizedPlaceholderBlinks() {
       var keyboard = new MathKeyboard<TestFont, char>(TestTypesettingContexts.Instance, new TestFont()) {
         CaretState = MathKeyboardCaretState.Shown
       };

--- a/CSharpMath.Editor/MathKeyboard.cs
+++ b/CSharpMath.Editor/MathKeyboard.cs
@@ -44,8 +44,9 @@ namespace CSharpMath.Editor {
         ResetPlaceholders(mathAtom.Superscript);
         ResetPlaceholders(mathAtom.Subscript);
         switch (mathAtom) {
-          case Atoms.Placeholder _:
-            mathAtom.Nucleus = "\u25A1";
+          case Atoms.Placeholder ph:
+            ph.ForeColor = LaTeXSettings.PlaceholderHidingColor;
+            ph.Nucleus = LaTeXSettings.PlaceholderHidingNucleus;
             break;
           case IMathListContainer container:
             foreach (var list in container.InnerLists)
@@ -62,10 +63,10 @@ namespace CSharpMath.Editor {
         blinkTimer.Start();
         if (value != MathKeyboardCaretState.Hidden &&
            MathList.AtomAt(_insertionIndex) is Atoms.Placeholder placeholder) 
-          (placeholder.Nucleus, _caretState) =
+          (placeholder.Nucleus, placeholder.ForeColor, _caretState) =
             value == MathKeyboardCaretState.TemporarilyHidden
-            ? ("\u25A1", MathKeyboardCaretState.TemporarilyHidden)
-            : ("\u25A0", MathKeyboardCaretState.ShownThroughPlaceholder);
+            ? (LaTeXSettings.PlaceholderHidingNucleus, LaTeXSettings.PlaceholderHidingColor, MathKeyboardCaretState.TemporarilyHidden)
+            : (LaTeXSettings.PlaceholderFullShowNucleus, LaTeXSettings.PlaceholderFullShowColor, MathKeyboardCaretState.ShownThroughPlaceholder);
         else _caretState = value;
         RecreateDisplayFromMathList();
         RedrawRequested?.Invoke(this, EventArgs.Empty);

--- a/CSharpMath.Editor/MathKeyboard.cs
+++ b/CSharpMath.Editor/MathKeyboard.cs
@@ -44,9 +44,9 @@ namespace CSharpMath.Editor {
         ResetPlaceholders(mathAtom.Superscript);
         ResetPlaceholders(mathAtom.Subscript);
         switch (mathAtom) {
-          case Atoms.Placeholder ph:
-            ph.ForeColor = LaTeXSettings.PlaceholderHidingColor;
-            ph.Nucleus = LaTeXSettings.PlaceholderHidingNucleus;
+          case Atoms.Placeholder placeholder:
+            placeholder.Color = LaTeXSettings.PlaceholderRestingColor;
+            placeholder.Nucleus = LaTeXSettings.PlaceholderRestingNucleus;
             break;
           case IMathListContainer container:
             foreach (var list in container.InnerLists)
@@ -63,10 +63,10 @@ namespace CSharpMath.Editor {
         blinkTimer.Start();
         if (value != MathKeyboardCaretState.Hidden &&
            MathList.AtomAt(_insertionIndex) is Atoms.Placeholder placeholder) 
-          (placeholder.Nucleus, placeholder.ForeColor, _caretState) =
+          (placeholder.Nucleus, placeholder.Color, _caretState) =
             value == MathKeyboardCaretState.TemporarilyHidden
-            ? (LaTeXSettings.PlaceholderHidingNucleus, LaTeXSettings.PlaceholderHidingColor, MathKeyboardCaretState.TemporarilyHidden)
-            : (LaTeXSettings.PlaceholderFullShowNucleus, LaTeXSettings.PlaceholderFullShowColor, MathKeyboardCaretState.ShownThroughPlaceholder);
+            ? (LaTeXSettings.PlaceholderRestingNucleus, LaTeXSettings.PlaceholderRestingColor, MathKeyboardCaretState.TemporarilyHidden)
+            : (LaTeXSettings.PlaceholderActiveNucleus, LaTeXSettings.PlaceholderActiveColor, MathKeyboardCaretState.ShownThroughPlaceholder);
         else _caretState = value;
         RecreateDisplayFromMathList();
         RedrawRequested?.Invoke(this, EventArgs.Empty);

--- a/CSharpMath/Atom/Atoms/Placeholder.cs
+++ b/CSharpMath/Atom/Atoms/Placeholder.cs
@@ -1,9 +1,11 @@
+using System.Drawing;
 namespace CSharpMath.Atom.Atoms {
   /// <summary>A placeholder for future input</summary>
   public sealed class Placeholder : MathAtom {
-    public Placeholder(string nucleus) : base(nucleus) { }
+    public Color? ForeColor { get; set; }
+    public Placeholder(string nucleus, Color? color) : base(nucleus) => ForeColor = color;
     public override bool ScriptsAllowed => true;
     public new Placeholder Clone(bool finalize) => (Placeholder)base.Clone(finalize);
-    protected override MathAtom CloneInside(bool finalize) => new Placeholder(Nucleus);
+    protected override MathAtom CloneInside(bool finalize) => new Placeholder(Nucleus, ForeColor);
   }
 }

--- a/CSharpMath/Atom/Atoms/Placeholder.cs
+++ b/CSharpMath/Atom/Atoms/Placeholder.cs
@@ -2,10 +2,10 @@ using System.Drawing;
 namespace CSharpMath.Atom.Atoms {
   /// <summary>A placeholder for future input</summary>
   public sealed class Placeholder : MathAtom {
-    public Color? ForeColor { get; set; }
-    public Placeholder(string nucleus, Color? color) : base(nucleus) => ForeColor = color;
+    public Color? Color { get; set; }
+    public Placeholder(string nucleus, Color? color) : base(nucleus) => Color = color;
     public override bool ScriptsAllowed => true;
     public new Placeholder Clone(bool finalize) => (Placeholder)base.Clone(finalize);
-    protected override MathAtom CloneInside(bool finalize) => new Placeholder(Nucleus, ForeColor);
+    protected override MathAtom CloneInside(bool finalize) => new Placeholder(Nucleus, Color);
   }
 }

--- a/CSharpMath/Atom/LaTeXSettings.cs
+++ b/CSharpMath/Atom/LaTeXSettings.cs
@@ -77,7 +77,7 @@ namespace CSharpMath.Atom {
         { @"\lrcorner", new Boundary("⌟") },
       };
 
-    static MathAtom? Dummy => Placeholder;
+    static readonly MathAtom? Dummy = Placeholder;
     public static Result<(MathAtom? Atom, MathList? Return)> Ok(MathAtom? atom) => Result.Ok((atom, (MathList?)null));
     public static Result<(MathAtom? Atom, MathList? Return)> OkStyled(MathList styled) => Result.Ok((Dummy, (MathList?)styled));
     public static Result<(MathAtom? Atom, MathList? Return)> OkStop(MathList @return) => Result.Ok(((MathAtom?)null, (MathList?)@return));
@@ -320,11 +320,11 @@ namespace CSharpMath.Atom {
       };
     public static MathAtom Times => new BinaryOperator("×");
     public static MathAtom Divide => new BinaryOperator("÷");
-    public static Color? PlaceholderHidingColor { get; set; }
-    public static Color? PlaceholderFullShowColor { get; set; }
-    public static string PlaceholderFullShowNucleus { get; set; } = "\u25A0";
-    public static string PlaceholderHidingNucleus { get; set; } = "\u25A1";
-    public static MathAtom Placeholder => new Placeholder(PlaceholderHidingNucleus, PlaceholderHidingColor);
+    public static Color? PlaceholderRestingColor { get; set; }
+    public static Color? PlaceholderActiveColor { get; set; }
+    public static string PlaceholderActiveNucleus { get; set; } = "\u25A0";
+    public static string PlaceholderRestingNucleus { get; set; } = "\u25A1";
+    public static MathAtom Placeholder => new Placeholder(PlaceholderRestingNucleus, PlaceholderRestingColor);
     public static MathList PlaceholderList => new MathList { Placeholder };
 
     public static AliasBiDictionary<string, FontStyle> FontStyles { get; } =

--- a/CSharpMath/Atom/LaTeXSettings.cs
+++ b/CSharpMath/Atom/LaTeXSettings.cs
@@ -77,7 +77,7 @@ namespace CSharpMath.Atom {
         { @"\lrcorner", new Boundary("⌟") },
       };
 
-    static readonly MathAtom? Dummy = Placeholder;
+    static MathAtom? Dummy => Placeholder;
     public static Result<(MathAtom? Atom, MathList? Return)> Ok(MathAtom? atom) => Result.Ok((atom, (MathList?)null));
     public static Result<(MathAtom? Atom, MathList? Return)> OkStyled(MathList styled) => Result.Ok((Dummy, (MathList?)styled));
     public static Result<(MathAtom? Atom, MathList? Return)> OkStop(MathList @return) => Result.Ok(((MathAtom?)null, (MathList?)@return));
@@ -320,7 +320,11 @@ namespace CSharpMath.Atom {
       };
     public static MathAtom Times => new BinaryOperator("×");
     public static MathAtom Divide => new BinaryOperator("÷");
-    public static MathAtom Placeholder => new Placeholder("\u25A1");
+    public static Color? PlaceholderHidingColor { get; set; }
+    public static Color? PlaceholderFullShowColor { get; set; }
+    public static string PlaceholderFullShowNucleus { get; set; } = "\u25A0";
+    public static string PlaceholderHidingNucleus { get; set; } = "\u25A1";
+    public static MathAtom Placeholder => new Placeholder(PlaceholderHidingNucleus, PlaceholderHidingColor);
     public static MathList PlaceholderList => new MathList { Placeholder };
 
     public static AliasBiDictionary<string, FontStyle> FontStyles { get; } =

--- a/CSharpMath/Atom/LaTeXSettings.cs
+++ b/CSharpMath/Atom/LaTeXSettings.cs
@@ -324,7 +324,7 @@ namespace CSharpMath.Atom {
     public static Color? PlaceholderActiveColor { get; set; }
     public static string PlaceholderActiveNucleus { get; set; } = "\u25A0";
     public static string PlaceholderRestingNucleus { get; set; } = "\u25A1";
-    public static MathAtom Placeholder => new Placeholder(PlaceholderRestingNucleus, PlaceholderRestingColor);
+    public static Placeholder Placeholder => new Placeholder(PlaceholderRestingNucleus, PlaceholderRestingColor);
     public static MathList PlaceholderList => new MathList { Placeholder };
 
     public static AliasBiDictionary<string, FontStyle> FontStyles { get; } =

--- a/CSharpMath/Display/AttributedGlyphRun.cs
+++ b/CSharpMath/Display/AttributedGlyphRun.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Drawing;
 using System.Linq;
 using System.Text;
 
@@ -7,9 +8,12 @@ namespace CSharpMath.Display {
   /// over the whole string. We use KernedGlyph objects instead of Glyphs to
   /// allow us to set kern on a per-glyph basis.</summary>
   public class AttributedGlyphRun<TFont, TGlyph> where TFont : FrontEnd.IFont<TGlyph> {
-    public AttributedGlyphRun(string text, IEnumerable<TGlyph> glyphs, TFont font, bool isPlaceHolder = false) {
+    public AttributedGlyphRun(string text, IEnumerable<TGlyph> glyphs, TFont font, bool isPlaceHolder = false, Color? foreColor = null) {
       Text = new StringBuilder(text);
       GlyphInfos = glyphs.Select(g => new GlyphInfo<TGlyph>(g)).ToList();
+      if (foreColor != null)
+        foreach(var g in GlyphInfos)
+          g.Foreground = foreColor;
       Font = font;
       Placeholder = isPlaceHolder;
     }

--- a/CSharpMath/Display/AttributedGlyphRun.cs
+++ b/CSharpMath/Display/AttributedGlyphRun.cs
@@ -10,7 +10,7 @@ namespace CSharpMath.Display {
   public class AttributedGlyphRun<TFont, TGlyph> where TFont : FrontEnd.IFont<TGlyph> {
     public AttributedGlyphRun(string text, IEnumerable<TGlyph> glyphs, TFont font, bool isPlaceHolder = false, Color? color = null) {
       Text = new StringBuilder(text);
-      GlyphInfos = glyphs.Select(g => new GlyphInfo<TGlyph>(g) { Foreground = color}).ToList();
+      GlyphInfos = glyphs.Select(g => new GlyphInfo<TGlyph>(g) { Foreground = color }).ToList();
       Font = font;
       Placeholder = isPlaceHolder;
     }

--- a/CSharpMath/Display/AttributedGlyphRun.cs
+++ b/CSharpMath/Display/AttributedGlyphRun.cs
@@ -8,12 +8,9 @@ namespace CSharpMath.Display {
   /// over the whole string. We use KernedGlyph objects instead of Glyphs to
   /// allow us to set kern on a per-glyph basis.</summary>
   public class AttributedGlyphRun<TFont, TGlyph> where TFont : FrontEnd.IFont<TGlyph> {
-    public AttributedGlyphRun(string text, IEnumerable<TGlyph> glyphs, TFont font, bool isPlaceHolder = false, Color? foreColor = null) {
+    public AttributedGlyphRun(string text, IEnumerable<TGlyph> glyphs, TFont font, bool isPlaceHolder = false, Color? color = null) {
       Text = new StringBuilder(text);
-      GlyphInfos = glyphs.Select(g => new GlyphInfo<TGlyph>(g)).ToList();
-      if (foreColor != null)
-        foreach(var g in GlyphInfos)
-          g.Foreground = foreColor;
+      GlyphInfos = glyphs.Select(g => new GlyphInfo<TGlyph>(g) { Foreground = color}).ToList();
       Font = font;
       Placeholder = isPlaceHolder;
     }

--- a/CSharpMath/Display/Typesetter.cs
+++ b/CSharpMath/Display/Typesetter.cs
@@ -337,7 +337,7 @@ namespace CSharpMath.Display {
               var nucleusText = atom.Nucleus;
               var glyphs = _context.GlyphFinder.FindGlyphs(_font, nucleusText);
               var current = new AttributedGlyphRun<TFont, TGlyph>(
-                nucleusText, glyphs, _font, atom is Placeholder, (atom as Placeholder)?.ForeColor);
+                nucleusText, glyphs, _font, atom is Placeholder, (atom as Placeholder)?.Color);
               _currentLine.AppendGlyphRun(current);
               if (_currentLineIndexRange.Location == Range.UndefinedInt)
                 _currentLineIndexRange = atom.IndexRange;

--- a/CSharpMath/Display/Typesetter.cs
+++ b/CSharpMath/Display/Typesetter.cs
@@ -337,7 +337,7 @@ namespace CSharpMath.Display {
               var nucleusText = atom.Nucleus;
               var glyphs = _context.GlyphFinder.FindGlyphs(_font, nucleusText);
               var current = new AttributedGlyphRun<TFont, TGlyph>(
-                nucleusText, glyphs, _font, atom is Placeholder);
+                nucleusText, glyphs, _font, atom is Placeholder, (atom as Placeholder)?.ForeColor);
               _currentLine.AppendGlyphRun(current);
               if (_currentLineIndexRange.Location == Range.UndefinedInt)
                 _currentLineIndexRange = atom.IndexRange;


### PR DESCRIPTION
In pull request #164, posting https://github.com/verybadcat/CSharpMath/pull/164#issuecomment-699458440, the idea came up to make the placeholder customizable in the keyboard output. While PR #164 is concerned with the display of the keyboard buttons themselves, this PR is about the math keyboard output.

Currently the placeholder has two possible appearances: a full black square and an empty square with a black border.

This pull request makes the Nucleus and the ForeColor of the placeholder customizable in both CaretStates.

An example of usage: instead of an empty square with a black border in the 'hiding' CaretState, you could choose a full square with another Color (gray, for instance).

An example test:
In CSharpMath.Forms.Example\CSharpMath.Forms.Example\EditorPage.xaml.cs
add the following lines at the top of the constructor of the EditorView:
```
      Atom.LaTeXSettings.PlaceholderHidingNucleus = "\u25A0";
      Atom.LaTeXSettings.PlaceholderHidingColor = Color.LightGray;
```
Open the Example project and go to the Editor tab. Click the fraction button. The output is:
![image](https://user-images.githubusercontent.com/32139898/94426706-46d0b980-018e-11eb-875c-21275d880d4d.png)
where the square in the numerator blinks, LightGray/Black.

I am willing to write unit tests after some form of preliminary approval of this pull request.
(And of course I will fix mistakes and refactor if needed.)