### PR TITLE
Remove blinking placeholder

### DIFF
--- a/CSharpMath.Editor.Tests/CaretTests.cs
+++ b/CSharpMath.Editor.Tests/CaretTests.cs
@@ -23,7 +23,7 @@ namespace CSharpMath.Editor.Tests {
   }
   public class CaretIsOverriddenByPlaceholder {
     [Fact]
-    public async Task Test() {
+    public void Test() {
       var keyboard = new MathKeyboard<TestFont, TGlyph>(TestTypesettingContexts.Instance, new TestFont()) {
         CaretState = MathKeyboardCaretState.Shown
       };
@@ -35,21 +35,11 @@ namespace CSharpMath.Editor.Tests {
       Assert.Equal(MathKeyboardCaretState.ShownThroughPlaceholder, keyboard.CaretState);
       Assert.Equal(DefaultPlaceholderSettings.RestingNucleus, outer.Nucleus);
       Assert.Equal(DefaultPlaceholderSettings.ActiveNucleus, inner.Nucleus);
-
-      await Task.Delay((int)MathKeyboard<TestFont, TGlyph>.DefaultBlinkMilliseconds + CaretBlinks.MillisecondBuffer);
-      Assert.Equal(MathKeyboardCaretState.TemporarilyHidden, keyboard.CaretState);
-      Assert.Equal(DefaultPlaceholderSettings.RestingNucleus, outer.Nucleus);
-      Assert.Equal(DefaultPlaceholderSettings.RestingNucleus, inner.Nucleus);
-
-      await Task.Delay((int)MathKeyboard<TestFont, TGlyph>.DefaultBlinkMilliseconds + CaretBlinks.MillisecondBuffer);
-      Assert.Equal(MathKeyboardCaretState.ShownThroughPlaceholder, keyboard.CaretState);
-      Assert.Equal(DefaultPlaceholderSettings.RestingNucleus, outer.Nucleus);
-      Assert.Equal(DefaultPlaceholderSettings.ActiveNucleus, inner.Nucleus);
     }
   }
   public class CaretMovesWithPlaceholder {
     [Fact]
-    public async Task Test() {
+    public void Test() {
       var keyboard = new MathKeyboard<TestFont, TGlyph>(TestTypesettingContexts.Instance, new TestFont()) {
         CaretState = MathKeyboardCaretState.Shown
       };
@@ -59,18 +49,6 @@ namespace CSharpMath.Editor.Tests {
       var outer = Assert.IsType<Atom.Atoms.Placeholder>(Assert.Single(keyboard.MathList));
       var inner = Assert.IsType<Atom.Atoms.Placeholder>(Assert.Single(outer.Subscript));
       Assert.Equal(MathKeyboardCaretState.ShownThroughPlaceholder, keyboard.CaretState);
-      Assert.Equal(DefaultPlaceholderSettings.RestingNucleus, outer.Nucleus);
-      Assert.Equal(DefaultPlaceholderSettings.ActiveNucleus, inner.Nucleus);
-
-      await Task.Delay((int)MathKeyboard<TestFont, TGlyph>.DefaultBlinkMilliseconds + CaretBlinks.MillisecondBuffer);
-      Assert.Equal(MathKeyboardCaretState.TemporarilyHidden, keyboard.CaretState);
-      keyboard.KeyPress(MathKeyboardInput.Left);
-      Assert.Equal(MathKeyboardCaretState.ShownThroughPlaceholder, keyboard.CaretState);
-      Assert.Equal(DefaultPlaceholderSettings.ActiveNucleus, outer.Nucleus);
-      Assert.Equal(DefaultPlaceholderSettings.RestingNucleus, inner.Nucleus);
-
-      Assert.Equal(MathKeyboardCaretState.ShownThroughPlaceholder, keyboard.CaretState);
-      keyboard.KeyPress(MathKeyboardInput.Right);
       Assert.Equal(DefaultPlaceholderSettings.RestingNucleus, outer.Nucleus);
       Assert.Equal(DefaultPlaceholderSettings.ActiveNucleus, inner.Nucleus);
     }
@@ -103,15 +81,13 @@ namespace CSharpMath.Editor.Tests {
   }
   public class CaretShowsAfterPlaceholderKeyPress {
     [Fact]
-    public async Task Test() {
+    public void Test() {
       var keyboard = new MathKeyboard<TestFont, TGlyph>(TestTypesettingContexts.Instance, new TestFont()) {
         CaretState = MathKeyboardCaretState.Hidden
       };
       Assert.Equal(MathKeyboardCaretState.Hidden, keyboard.CaretState);
       keyboard.KeyPress(MathKeyboardInput.Power);
       Assert.Equal(MathKeyboardCaretState.ShownThroughPlaceholder, keyboard.CaretState);
-      await Task.Delay((int)MathKeyboard<TestFont, TGlyph>.DefaultBlinkMilliseconds + CaretBlinks.MillisecondBuffer);
-      Assert.Equal(MathKeyboardCaretState.TemporarilyHidden, keyboard.CaretState);
     }
   }
   public class CaretHidesAfterReturnAndDismiss { 
@@ -221,7 +197,7 @@ namespace CSharpMath.Editor.Tests {
       LaTeXSettings.PlaceholderRestingColor = DefaultPlaceholderSettings.RestingColor;
     }
     [Fact]
-    public async Task CustomizedPlaceholderBlinks() {
+    public void CustomizedPlaceholderBlinks() {
       var keyboard = new MathKeyboard<TestFont, TGlyph>(TestTypesettingContexts.Instance, new TestFont()) {
         CaretState = MathKeyboardCaretState.Shown
       };
@@ -230,20 +206,6 @@ namespace CSharpMath.Editor.Tests {
       keyboard.KeyPress(MathKeyboardInput.Subscript);
       var outer = Assert.IsType<Atom.Atoms.Placeholder>(Assert.Single(keyboard.MathList));
       var inner = Assert.IsType<Atom.Atoms.Placeholder>(Assert.Single(outer.Subscript));
-      Assert.Equal(MathKeyboardCaretState.ShownThroughPlaceholder, keyboard.CaretState);
-      Assert.Equal("😐", outer.Nucleus);
-      Assert.Equal(System.Drawing.Color.Blue, outer.Color);
-      Assert.Equal("😀", inner.Nucleus);
-      Assert.Equal(System.Drawing.Color.Green, inner.Color);
-
-      await Task.Delay((int)MathKeyboard<TestFont, TGlyph>.DefaultBlinkMilliseconds + CaretBlinks.MillisecondBuffer);
-      Assert.Equal(MathKeyboardCaretState.TemporarilyHidden, keyboard.CaretState);
-      Assert.Equal("😐", outer.Nucleus);
-      Assert.Equal(System.Drawing.Color.Blue, outer.Color);
-      Assert.Equal("😐", inner.Nucleus);
-      Assert.Equal(System.Drawing.Color.Blue, inner.Color);
-
-      await Task.Delay((int)MathKeyboard<TestFont, TGlyph>.DefaultBlinkMilliseconds + CaretBlinks.MillisecondBuffer);
       Assert.Equal(MathKeyboardCaretState.ShownThroughPlaceholder, keyboard.CaretState);
       Assert.Equal("😐", outer.Nucleus);
       Assert.Equal(System.Drawing.Color.Blue, outer.Color);

--- a/CSharpMath.Editor/MathKeyboard.cs
+++ b/CSharpMath.Editor/MathKeyboard.cs
@@ -63,9 +63,7 @@ namespace CSharpMath.Editor {
         blinkTimer.Start();
         if (value != MathKeyboardCaretState.Hidden && MathList.AtomAt(_insertionIndex) is Atoms.Placeholder placeholder)
           (placeholder.Nucleus, placeholder.Color, _caretState) =
-            LaTeXSettings.PlaceholderBlinks && value == MathKeyboardCaretState.TemporarilyHidden
-            ? (LaTeXSettings.PlaceholderRestingNucleus, LaTeXSettings.PlaceholderRestingColor, MathKeyboardCaretState.TemporarilyHidden)
-            : (LaTeXSettings.PlaceholderActiveNucleus, LaTeXSettings.PlaceholderActiveColor, MathKeyboardCaretState.ShownThroughPlaceholder);
+            (LaTeXSettings.PlaceholderActiveNucleus, LaTeXSettings.PlaceholderActiveColor, MathKeyboardCaretState.ShownThroughPlaceholder);
         else _caretState = value;
         RecreateDisplayFromMathList();
         RedrawRequested?.Invoke(this, EventArgs.Empty);

--- a/CSharpMath.Editor/MathKeyboard.cs
+++ b/CSharpMath.Editor/MathKeyboard.cs
@@ -63,7 +63,9 @@ namespace CSharpMath.Editor {
         blinkTimer.Start();
         if (value != MathKeyboardCaretState.Hidden && MathList.AtomAt(_insertionIndex) is Atoms.Placeholder placeholder)
           (placeholder.Nucleus, placeholder.Color, _caretState) =
-            (LaTeXSettings.PlaceholderActiveNucleus, LaTeXSettings.PlaceholderActiveColor, MathKeyboardCaretState.ShownThroughPlaceholder);
+            LaTeXSettings.PlaceholderBlinks && value == MathKeyboardCaretState.TemporarilyHidden
+            ? (LaTeXSettings.PlaceholderRestingNucleus, LaTeXSettings.PlaceholderRestingColor, MathKeyboardCaretState.TemporarilyHidden)
+            : (LaTeXSettings.PlaceholderActiveNucleus, LaTeXSettings.PlaceholderActiveColor, MathKeyboardCaretState.ShownThroughPlaceholder);
         else _caretState = value;
         RecreateDisplayFromMathList();
         RedrawRequested?.Invoke(this, EventArgs.Empty);

--- a/CSharpMath.Editor/MathKeyboard.cs
+++ b/CSharpMath.Editor/MathKeyboard.cs
@@ -61,12 +61,9 @@ namespace CSharpMath.Editor {
       set {
         blinkTimer.Stop();
         blinkTimer.Start();
-        if (value != MathKeyboardCaretState.Hidden &&
-           MathList.AtomAt(_insertionIndex) is Atoms.Placeholder placeholder) 
+        if (value != MathKeyboardCaretState.Hidden && MathList.AtomAt(_insertionIndex) is Atoms.Placeholder placeholder)
           (placeholder.Nucleus, placeholder.Color, _caretState) =
-            value == MathKeyboardCaretState.TemporarilyHidden
-            ? (LaTeXSettings.PlaceholderRestingNucleus, LaTeXSettings.PlaceholderRestingColor, MathKeyboardCaretState.TemporarilyHidden)
-            : (LaTeXSettings.PlaceholderActiveNucleus, LaTeXSettings.PlaceholderActiveColor, MathKeyboardCaretState.ShownThroughPlaceholder);
+            (LaTeXSettings.PlaceholderActiveNucleus, LaTeXSettings.PlaceholderActiveColor, MathKeyboardCaretState.ShownThroughPlaceholder);
         else _caretState = value;
         RecreateDisplayFromMathList();
         RedrawRequested?.Invoke(this, EventArgs.Empty);

--- a/CSharpMath/Atom/LaTeXSettings.cs
+++ b/CSharpMath/Atom/LaTeXSettings.cs
@@ -324,6 +324,7 @@ namespace CSharpMath.Atom {
     public static Color? PlaceholderActiveColor { get; set; }
     public static string PlaceholderActiveNucleus { get; set; } = "\u25A0";
     public static string PlaceholderRestingNucleus { get; set; } = "\u25A1";
+    public static bool PlaceholderBlinks { get; set; } = false;
     public static Placeholder Placeholder => new Placeholder(PlaceholderRestingNucleus, PlaceholderRestingColor);
     public static MathList PlaceholderList => new MathList { Placeholder };
 

--- a/CSharpMath/Atom/LaTeXSettings.cs
+++ b/CSharpMath/Atom/LaTeXSettings.cs
@@ -324,7 +324,6 @@ namespace CSharpMath.Atom {
     public static Color? PlaceholderActiveColor { get; set; }
     public static string PlaceholderActiveNucleus { get; set; } = "\u25A0";
     public static string PlaceholderRestingNucleus { get; set; } = "\u25A1";
-    public static bool PlaceholderBlinks { get; set; } = false;
     public static Placeholder Placeholder => new Placeholder(PlaceholderRestingNucleus, PlaceholderRestingColor);
     public static MathList PlaceholderList => new MathList { Placeholder };
 

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
Word, MathQuill, and LyX don't have blinking placeholders.

They are visually unattractive and not useful UX because a large block blinks which is already easy to identify, unlike the cursor where a small line blinks which is harder to identify.