### PR TITLE
Fix ci build

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -13,9 +13,9 @@ jobs:
       with:
         dotnet-version: '3.1.401'
     - name: Setup NuGet
-      uses: NuGet/setup-nuget@v1.0.2
+      uses: NuGet/setup-nuget@v1.0.5
     - name: Setup MSBuild Path
-      uses: warrenbuckley/Setup-MSBuild@v1
+      uses: microsoft/setup-msbuild@v1.0.2
     - name: Restore NuGet Packages
       run: nuget restore CSharpMath.sln
     - name: Build Everything

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -26,6 +26,10 @@ jobs:
         }
         # retry 5 times since dotnet outdated fails often: https://github.com/jerriep/dotnet-outdated/issues/299
         update || update || update || update || update
+    - name: Clean
+      run: |
+        dotnet tool install --global scrub
+        scrub --ask false
     - name: Restore
       run: dotnet restore CSharpMath.CrossPlatform.slnf
     - name: Build

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -26,11 +26,7 @@ jobs:
         }
         # retry 5 times since dotnet outdated fails often: https://github.com/jerriep/dotnet-outdated/issues/299
         update || update || update || update || update
-    - name: Restore
-      run: dotnet restore CSharpMath.CrossPlatform.slnf
-    - name: Build
-      run: dotnet build CSharpMath.CrossPlatform.slnf -c Release --no-restore
-    - name: Test
+    - name: Build and Test
       env:
         RELEASE_NOTES: |
           # ${{ steps.release_drafter.outputs.name }}
@@ -45,7 +41,7 @@ jobs:
         
         # --collect:"XPlat Code Coverage" means collect test coverage with https://github.com/coverlet-coverage/coverlet
         # Coverlet settings come after --: https://github.com/coverlet-coverage/coverlet/blob/master/Documentation/VSTestIntegration.md#advanced-options-supported-via-runsettings
-        dotnet test CSharpMath.CrossPlatform.slnf -c Release --no-build -l GitHubActions --blame --collect:"XPlat Code Coverage" -r .testcoverage -p:PackageReleaseNotes="$RELEASE_NOTES" -p:PackageVersion=${{ steps.release_drafter.outputs.tag_name || format('{0}-pr', github.event.number) }}-ci-${{ github.sha }} -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.IncludeTestAssembly=true
+        dotnet test CSharpMath.CrossPlatform.slnf -c Release -l GitHubActions --blame --collect:"XPlat Code Coverage" -r .testcoverage -p:PackageReleaseNotes="$RELEASE_NOTES" -p:PackageVersion=${{ steps.release_drafter.outputs.tag_name || format('{0}-pr', github.event.number) }}-ci-${{ github.sha }} -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.IncludeTestAssembly=true
     - name: Run ReportGenerator on Test Coverage results
       uses: danielpalme/ReportGenerator-GitHub-Action@4.6.7
       with:

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -26,10 +26,6 @@ jobs:
         }
         # retry 5 times since dotnet outdated fails often: https://github.com/jerriep/dotnet-outdated/issues/299
         update || update || update || update || update
-    - name: Clean
-      run: |
-        dotnet tool install --global scrub
-        scrub --ask false
     - name: Restore
       run: dotnet restore CSharpMath.CrossPlatform.slnf
     - name: Build

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -26,7 +26,11 @@ jobs:
         }
         # retry 5 times since dotnet outdated fails often: https://github.com/jerriep/dotnet-outdated/issues/299
         update || update || update || update || update
-    - name: Build and Test
+    - name: Restore
+      run: dotnet restore CSharpMath.CrossPlatform.slnf
+    - name: Build
+      run: dotnet build CSharpMath.CrossPlatform.slnf -c Release --no-restore
+    - name: Test
       env:
         RELEASE_NOTES: |
           # ${{ steps.release_drafter.outputs.name }}
@@ -41,7 +45,7 @@ jobs:
         
         # --collect:"XPlat Code Coverage" means collect test coverage with https://github.com/coverlet-coverage/coverlet
         # Coverlet settings come after --: https://github.com/coverlet-coverage/coverlet/blob/master/Documentation/VSTestIntegration.md#advanced-options-supported-via-runsettings
-        dotnet test CSharpMath.CrossPlatform.slnf -c Release -l GitHubActions --blame --collect:"XPlat Code Coverage" -r .testcoverage -p:PackageReleaseNotes="$RELEASE_NOTES" -p:PackageVersion=${{ steps.release_drafter.outputs.tag_name || format('{0}-pr', github.event.number) }}-ci-${{ github.sha }} -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.IncludeTestAssembly=true
+        dotnet test CSharpMath.CrossPlatform.slnf -c Release --no-build -l GitHubActions --blame --collect:"XPlat Code Coverage" -r .testcoverage -p:PackageReleaseNotes="$RELEASE_NOTES" -p:PackageVersion=${{ steps.release_drafter.outputs.tag_name || format('{0}-pr', github.event.number) }}-ci-${{ github.sha }} -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.IncludeTestAssembly=true
     - name: Run ReportGenerator on Test Coverage results
       uses: danielpalme/ReportGenerator-GitHub-Action@4.6.7
       with:

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -1,4 +1,4 @@
-name: Test
+﻿name: Test
 
 on: [push, pull_request]
 jobs:
@@ -22,7 +22,7 @@ jobs:
         dotnet tool install -g dotnet-outdated
         update() {
           dotnet outdated -u CSharpMath.Xaml.Tests.NuGet
-          dotnet outdated -pre Always -inc CSharpMath -inc Avalonia -u CSharpMath.Xaml.Tests.NuGet
+          dotnet outdated -pre Always -inc CSharpMath -u CSharpMath.Xaml.Tests.NuGet
         }
         # retry 5 times since dotnet outdated fails often: https://github.com/jerriep/dotnet-outdated/issues/299
         update || update || update || update || update

--- a/CSharpMath.Xaml.Tests.NuGet/CSharpMath.Xaml.Tests.NuGet.csproj
+++ b/CSharpMath.Xaml.Tests.NuGet/CSharpMath.Xaml.Tests.NuGet.csproj
@@ -2,7 +2,7 @@
   <ItemGroup>
     <PackageReference Include="CSharpMath.Avalonia" Version="0.5.0-alpha4" />
     <PackageReference Include="CSharpMath.Forms" Version="0.5.0-alpha4" />
-    <PackageReference Include="Avalonia.Skia" Version="0.10.0-preview2" />
+    <PackageReference Include="Avalonia.Skia" Version="0.10.0-preview5" />
     <Compile Include="../CSharpMath.Xaml.Tests/XamarinFormsCrc64.cs" Link="XamarinFormsCrc64.cs" />
     <Compile Include="../CSharpMath.Xaml.Tests/XamarinFormsMockPlatformServices.cs" Link="XamarinFormsMockPlatformServices.cs" />
   </ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,4 +1,4 @@
-<!--Directory.Build.props: MSBuild properties that are included in every project-->
+﻿<!--Directory.Build.props: MSBuild properties that are included in every project-->
 <!--Info: https://docs.microsoft.com/en-us/visualstudio/msbuild/customize-your-build?view=vs-2019#directorybuildprops-and-directorybuildtargets-->
 <Project InitialTargets="SetDefaultPackageVersion">
   <PropertyGroup Condition="$(MSBuildProjectName.Contains('Test')) And !$(MSBuildProjectName.Contains('Ios'))">
@@ -15,7 +15,7 @@
   <!--Don't apply to Typography projects-->
   <PropertyGroup Condition="$(MSBuildProjectName.StartsWith('CSharpMath'))">
     <!--CSharpMath-specific properties for centralized control of values-->
-    <AvaloniaVersion>0.10.0-preview5</AvaloniaVersion>
+    <AvaloniaVersion>0.10.0-rc1</AvaloniaVersion>
 
     <!--C# code properties-->
     <LangVersion>preview</LangVersion>


### PR DESCRIPTION
* [x] Build / 
* [x] Test / Core [ workaround ]

For `Test / Core` I had to change version for `Avalonia.Skia` package manually since I didn't find any good (and easy to implement) way to specify the same version of `Avalonia`.

 Also I turned off (temporarily) automatic updates for `Avalonia.Skia` package.

Test / Ios is unrelated.