### PR TITLE
Provide workaround for #192

### DIFF
--- a/CSharpMath.Rendering/Text/TextLaTeXParser.cs
+++ b/CSharpMath.Rendering/Text/TextLaTeXParser.cs
@@ -38,6 +38,8 @@ string BreakText(string text, string seperator = "|")
 }
 BreakText(@"Here are some text $1 + 12 \frac23 \sqrt4$ $$Display$$ text")
      */
+    /// <summary>Handle additional languages</summary>
+    public static List<BreakingEngine> AdditionalBreakingEngines { get; } = new();
     public static Result<TextAtom> TextAtomFromLaTeX(string latexSource) {
       if (string.IsNullOrEmpty(latexSource))
         return new TextAtom.List(Array.Empty<TextAtom>());
@@ -54,6 +56,8 @@ BreakText(@"Here are some text $1 + 12 \frac23 \sqrt4$ $$Display$$ text")
         BreakNumberAfterText = true,
         ThrowIfCharOutOfRange = false
       };
+      foreach (var engine in AdditionalBreakingEngines)
+        breaker.AddBreakingEngine(engine);
       breaker.BreakWords(latexSource);
 
       Result CheckDollarCount(int startAt, ref int endAt, TextAtomListBuilder atoms) {


### PR DESCRIPTION
So that
```cs
class RussianBreakingEngine : Typography.TextBreak.EngBreakingEngine {
  public override bool CanHandle(char c) => c is >= '\u0400' and <= '\u052f'; // Unicode Cyrillic and Cyrillic Supplement
}
CSharpMath.Rendering.Text.TextLaTeXParser.AdditionalBreakingEngines.Add(new RussianBreakingEngine());
```
can be used for #192 while awaiting Typography support.