### PR TITLE
Remove EnumGetValues

### DIFF
--- a/CSharpMath.Editor/SubIndexTypeMismatchException.cs
+++ b/CSharpMath.Editor/SubIndexTypeMismatchException.cs
@@ -7,8 +7,6 @@ namespace CSharpMath.Editor {
     public SubIndexTypeMismatchException(Type atomType, MathListIndex index) : base(
       $"{atomType} not found at index {index.AtomIndex}.") { }
     public SubIndexTypeMismatchException(MathListIndex index) : base(
-      Array.IndexOf(typeof(MathListSubIndexType).GetEnumValues(), index.SubIndexType) == -1
-      ? $"{index.SubIndexType} is an invalid subindex type."
-      : $"{index.SubIndexType} not found at index {index.AtomIndex}.") { }
+      $"{index.SubIndexType} not found at index {index.AtomIndex}.") { }
   }
 }


### PR DESCRIPTION
Remove a usage of Enum.GetValues, which is based on reflection and not trim compatible.

Fixes https://github.com/verybadcat/CSharpMath/issues/227