### PR TITLE
update Avalonia support to 11.0.10

### DIFF
--- a/CSharpMath.Avalonia.Example/CSharpMath.Avalonia.Example.csproj
+++ b/CSharpMath.Avalonia.Example/CSharpMath.Avalonia.Example.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>WinExe</OutputType>
   </PropertyGroup>
 


### PR DESCRIPTION
With this update, CSharpMath will be able to support the latest Avalonia version. I updated the Avalonia package to 11.0.10 and changed the example code to .NET 8.0.